### PR TITLE
feat(DPG-001): add bump and list commands with updated CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ It relies on:
 * Canonical context encoding
 * Bias-free character selection
 * Profile-driven workflow
+* Cross-platform CLI with profile generation, listing, and bump/save workflow
 * Full test suite (fast + slow paths)
 
 ---
@@ -148,26 +149,58 @@ npm run test:slow
 
 ## CLI
 
-DPG v2 includes a CLI for generating a password from an existing profile and copying it to the clipboard.
+DPG v2 includes a CLI for generating passwords from existing profiles.
 
-### Usage
+### Generate from profile
 
     dpg -p github-main
 
 This will:
+
 - load the profile with label `github-main`
 - prompt for the master password
 - generate the current password
 - copy it to the clipboard
 
-### Options
+### Show the generated password
 
-    dpg -p <label>
-    dpg --profile <label>
-    dpg -p <label> --show
+    dpg -p github-main --show
+
+This also prints the generated password to stdout.
+
+### List profiles
+
+    dpg --list
+
+This prints the available profiles in sorted order.
+
+### Bump a profile counter without saving
+
+    dpg -b github-main
+
+This will:
+
+- load the profile
+- increment the counter in memory only
+- generate the password for the bumped counter
+- copy it to the clipboard
+- report the old and new counter values
+
+### Bump and save
+
+    dpg -b github-main --save
+
+This does the same thing, but also persists the incremented counter back to `profiles.json`, and reports it as saved.
+
+### Bump, save, and show
+
+    dpg -b github-main --save --show
+
+This also prints the generated password to stdout.
+
+### Help
+
     dpg --help
-
-`--show` also prints the generated password to stdout.
 
 ### Profiles file location
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
   "name": "dpg-v2",
-  "version": "2.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dpg-v2",
-      "version": "2.0.0",
+      "version": "0.1.0",
       "dependencies": {
-        "argon2id": "^1.0.1"
+        "argon2id": "^1.0.0"
+      },
+      "bin": {
+        "dpg": "src/cli.js"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
-        "vitest": "^3.0.0"
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/src/cli-args.js
+++ b/src/cli-args.js
@@ -1,4 +1,15 @@
 /**
+ * @typedef {{
+ *   profileLabel: string | null,
+ *   show: boolean,
+ *   help: boolean,
+ *   list: boolean,
+ *   bump: string | null,
+ *   save: boolean
+ * }} CliArgs
+ */
+
+/**
  * @param {string[]} argv
  * @returns {{
  *   profileLabel: string | null,

--- a/src/cli-args.js
+++ b/src/cli-args.js
@@ -1,11 +1,21 @@
 /**
  * @param {string[]} argv
- * @returns {{ profileLabel: string | null, show: boolean, help: boolean }}
+ * @returns {{
+ *   profileLabel: string | null,
+ *   show: boolean,
+ *   help: boolean,
+ *   list: boolean,
+ *   bump: string | null,
+ *   save: boolean
+ * }}
  */
 export function parseArgs(argv) {
   let profileLabel = null
   let show = false
   let help = false
+  let list = false
+  let bump = null
+  let save = false
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
@@ -16,6 +26,16 @@ export function parseArgs(argv) {
         throw new Error('Missing profile label after -p/--profile')
       }
       profileLabel = next
+    } else if (arg === '-b' || arg === '--bump') {
+      const next = argv[++i]
+      if (!next) {
+        throw new Error('Missing profile label after -b/--bump')
+      }
+      bump = next
+    } else if (arg === '--list') {
+      list = true
+    } else if (arg === '--save') {
+      save = true
     } else if (arg === '--show') {
       show = true
     } else if (arg === '--help' || arg === '-h') {
@@ -25,7 +45,7 @@ export function parseArgs(argv) {
     }
   }
 
-  return { profileLabel, show, help }
+  return { profileLabel, show, help, list, bump, save }
 }
 
 export function usageText() {
@@ -34,6 +54,19 @@ export function usageText() {
     '  dpg -p <label>',
     '  dpg --profile <label>',
     '  dpg -p <label> --show',
-    '  dpg --help'
+    '  dpg --list',
+    '  dpg -b <label>',
+    '  dpg -b <label> --show',
+    '  dpg -b <label> --save',
+    '  dpg -b <label> --save --show',
+    '  dpg --help',
+    '',
+    'Options:',
+    '  -p, --profile <label>   Generate password from existing profile',
+    '  -b, --bump <label>      Generate password using counter + 1',
+    '      --save              Persist changes made by --bump',
+    '      --show              Print generated password to stdout',
+    '      --list              List available profiles',
+    '  -h, --help              Show this help text'
   ].join('\n')
 }

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -1,17 +1,32 @@
-import {loadProfileByLabel} from './profiles-file.js'
+import {loadProfileByLabel, saveProfiles, loadAllProfiles} from './profiles-file.js'
 import {promptForMasterPassword} from './prompt.js'
 import {generatePassword} from './generate.js'
 import {copyToClipboard} from './clipboard.js'
 import {usageText} from './cli-args.js'
 
 /**
- * @param {{ profileLabel: string | null, show: boolean, help: boolean }} args
- * @param {object=} deps
+ * @typedef {{
+ *   loadProfileByLabel?: (label: string) => Promise<any>,
+ *   loadAllProfiles?: () => Promise<any[]>,
+ *   saveProfiles?: (profiles: any[]) => Promise<void>,
+ *   promptForMasterPassword?: () => Promise<string>,
+ *   generatePassword?: (master: string, profile: any) => Promise<string>,
+ *   copyToClipboard?: (text: string) => Promise<void>,
+ *   stdout?: { write: (s: string) => void },
+ *   stderr?: { write: (s: string) => void }
+ * }} CliDeps
+ */
+
+/**
+ * @param {{ profileLabel: string | null, show: boolean, help: boolean, list: boolean , bump: string | null , save: boolean }} args
+ * @param {CliDeps=} deps
  * @returns {Promise<number>}
  */
 export async function runCli(args, deps = {}) {
   const {
     loadProfileByLabel: load = loadProfileByLabel,
+    loadAllProfiles: loadAll = loadAllProfiles,
+    saveProfiles: save = saveProfiles,
     promptForMasterPassword: prompt = promptForMasterPassword,
     generatePassword: generate = generatePassword,
     copyToClipboard: copy = copyToClipboard,
@@ -21,6 +36,59 @@ export async function runCli(args, deps = {}) {
 
   if (args.help) {
     stdout.write(usageText() + '\n')
+    return 0
+  }
+
+  if (args.list) {
+    const profiles = await loadAll()
+
+    if (profiles.length === 0) {
+      stdout.write('No profiles found.\n')
+      return 0
+    }
+
+    const sorted = [...profiles].sort((a, b) =>
+      a.label.localeCompare(b.label)
+    )
+
+    for (const p of sorted) {
+      stdout.write(`${p.label} (${p.service}) [counter=${p.counter}]\n`)
+    }
+
+    return 0
+  }
+
+  if (args.bump) {
+    const profile = await load(args.bump)
+
+    const oldCounter = profile.counter
+    const newCounter = oldCounter + 1
+
+    const updatedProfile = {
+      ...profile,
+      counter: newCounter
+    }
+
+    const masterPassword = await prompt()
+    const password = await generate(masterPassword, updatedProfile)
+
+    await copy(password)
+
+    const savedSuffix = args.save ? ' (saved)' : ''
+    stdout.write(`Counter: ${oldCounter} → ${newCounter}${savedSuffix}\n`)
+
+    if (args.show) {
+      stdout.write(password + '\n')
+    }
+
+    if (args.save) {
+      const all = await loadAll()
+      const updated = all.map(p =>
+        p.label === profile.label ? updatedProfile : p
+      )
+      await save(updated)
+    }
+
     return 0
   }
 

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -18,7 +18,7 @@ import {usageText} from './cli-args.js'
  */
 
 /**
- * @param {{ profileLabel: string | null, show: boolean, help: boolean, list: boolean , bump: string | null , save: boolean }} args
+ * @param {import('./cli-args.js').CliArgs} args
  * @param {CliDeps=} deps
  * @returns {Promise<number>}
  */
@@ -39,65 +39,75 @@ export async function runCli(args, deps = {}) {
     return 0
   }
 
-  if (args.list) {
-    const profiles = await loadAll()
-
-    if (profiles.length === 0) {
-      stdout.write('No profiles found.\n')
-      return 0
-    }
-
-    const sorted = [...profiles].sort((a, b) =>
-      a.label.localeCompare(b.label)
-    )
-
-    for (const p of sorted) {
-      stdout.write(`${p.label} (${p.service}) [counter=${p.counter}]\n`)
-    }
-
-    return 0
-  }
-
-  if (args.bump) {
-    const profile = await load(args.bump)
-
-    const oldCounter = profile.counter
-    const newCounter = oldCounter + 1
-
-    const updatedProfile = {
-      ...profile,
-      counter: newCounter
-    }
-
-    const masterPassword = await prompt()
-    const password = await generate(masterPassword, updatedProfile)
-
-    await copy(password)
-
-    const savedSuffix = args.save ? ' (saved)' : ''
-    stdout.write(`Counter: ${oldCounter} → ${newCounter}${savedSuffix}\n`)
-
-    if (args.show) {
-      stdout.write(password + '\n')
-    }
-
-    if (args.save) {
-      const all = await loadAll()
-      const updated = all.map(p =>
-        p.label === profile.label ? updatedProfile : p
-      )
-      await save(updated)
-    }
-
-    return 0
-  }
-
-  if (!args.profileLabel) {
-    stderr.write('A profile label is required. Use -p <label>.\n')
+  if (!args.profileLabel && !args.bump && !args.list) {
+    stderr.write('No command specified. Use -p <label>, -b <label>, or --list. See -h for help.\n')
     return 1
   }
 
   try {
+    if (args.list) {
+      const profiles = await loadAll()
+
+      if (profiles.length === 0) {
+        stdout.write('No profiles found.\n')
+        return 0
+      }
+
+      const sorted = [...profiles].sort((a, b) =>
+        a.label.localeCompare(b.label)
+      )
+
+      for (const p of sorted) {
+        stdout.write(`${p.label} (${p.service}) [counter=${p.counter}]\n`)
+      }
+
+      return 0
+    }
+
+    if (args.bump) {
+      const profile = await load(args.bump)
+
+      const oldCounter = profile.counter
+      const newCounter = oldCounter + 1
+
+      const updatedProfile = {
+        ...profile,
+        counter: newCounter
+      }
+
+      const masterPassword = await prompt()
+      const password = await generate(masterPassword, updatedProfile)
+
+      await copy(password)
+
+      if (args.show) {
+        stdout.write(password + '\n')
+      }
+
+      if (args.save) {
+        const now = new Date().toISOString()
+
+        const updatedProfile = {
+          ...profile,
+          counter: newCounter,
+          updatedAt: now
+        }
+
+        const all = await loadAll()
+        const updated = all.map(p =>
+          p.label === profile.label ? updatedProfile : p
+        )
+
+        await save(updated)
+
+        stdout.write(`Counter: ${oldCounter} → ${newCounter} (saved)\n`)
+      } else {
+        stdout.write(`Counter: ${oldCounter} → ${newCounter}\n`)
+      }
+
+      return 0
+    }
+
     const profile = await load(args.profileLabel)
     const masterPassword = await prompt()
     const password = await generate(masterPassword, profile)
@@ -112,6 +122,7 @@ export async function runCli(args, deps = {}) {
     }
 
     return 0
+
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     stderr.write(message + '\n')

--- a/src/profiles-file.js
+++ b/src/profiles-file.js
@@ -62,3 +62,29 @@ export async function loadProfileByLabel(label, options = {}) {
 
   return findProfileByLabel(parsed, label)
 }
+
+export async function loadAllProfiles(options = {}) {
+  const profilesPath = options.profilesPath ?? resolveProfilesPath()
+  const text = await fs.readFile(profilesPath, 'utf8')
+  const parsed = JSON.parse(text)
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('Profiles file must contain a JSON array')
+  }
+
+  return parsed
+}
+
+export async function saveProfiles(profiles, options = {}) {
+  const profilesPath = options.profilesPath ?? resolveProfilesPath()
+  const tmpPath = profilesPath + '.tmp'
+
+  const sorted = [...profiles].sort((a, b) =>
+    a.label.localeCompare(b.label)
+  )
+
+  const json = JSON.stringify(sorted)
+
+  await fs.writeFile(tmpPath, json, 'utf8')
+  await fs.rename(tmpPath, profilesPath)
+}

--- a/src/profiles-file.js
+++ b/src/profiles-file.js
@@ -3,6 +3,22 @@ import path from 'node:path'
 import fs from 'node:fs/promises'
 
 /**
+ * @typedef {{
+ *   version: string,
+ *   label: string,
+ *   service: string,
+ *   account?: string,
+ *   counter: number,
+ *   length: number,
+ *   require: string[],
+ *   symbolSet?: string,
+ *   notes?: string,
+ *   createdAt?: string,
+ *   updatedAt?: string
+ * }} Profile
+ */
+
+/**
  * @param {{ platform?: string, homeDir?: string }=} options
  * @returns {string}
  */
@@ -65,7 +81,17 @@ export async function loadProfileByLabel(label, options = {}) {
 
 export async function loadAllProfiles(options = {}) {
   const profilesPath = options.profilesPath ?? resolveProfilesPath()
-  const text = await fs.readFile(profilesPath, 'utf8')
+
+  let text
+  try {
+    text = await fs.readFile(profilesPath, 'utf8')
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return []
+    }
+    throw err
+  }
+
   const parsed = JSON.parse(text)
 
   if (!Array.isArray(parsed)) {
@@ -75,6 +101,11 @@ export async function loadAllProfiles(options = {}) {
   return parsed
 }
 
+/**
+ * @param {Profile[]} profiles
+ * @param {{ profilesPath?: string }=} options
+ * @returns {Promise<void>}
+ */
 export async function saveProfiles(profiles, options = {}) {
   const profilesPath = options.profilesPath ?? resolveProfilesPath()
   const tmpPath = profilesPath + '.tmp'

--- a/test/bump.test.js
+++ b/test/bump.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runCli } from '../src/cli-runner.js'
+import { makeProfile } from './fixtures/profiles.js'
+import { makeCliArgs } from './fixtures/cli.js'
+
+describe('bump command', () => {
+  it('bumps counter in memory and generates password', async () => {
+    const profile = makeProfile({ label: 'github', counter: 5 })
+
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ bump: 'github', show: false, save: false }),
+      {
+        loadProfileByLabel: async () => profile,
+        generatePassword: async () => 'pw',
+        copyToClipboard: async () => {},
+        promptForMasterPassword: async () => 'master',
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+
+    const output = stdout.write.mock.calls.map(c => c[0]).join('')
+    expect(output).toMatch(/5/)
+    expect(output).toMatch(/6/)
+  })
+
+  it('persists counter when --save is used', async () => {
+    const profile = makeProfile({ label: 'github', counter: 5 })
+
+    let savedProfiles = null
+
+    const exitCode = await runCli(
+      makeCliArgs({ bump: 'github', show: false, save: true }),
+      {
+        loadProfileByLabel: async label => {
+          if (label === 'github') return profile
+          throw new Error(`Profile not found: ${label}`)
+        },
+        loadAllProfiles: async () => [profile],
+        saveProfiles: async profiles => {
+          savedProfiles = profiles
+        },
+        generatePassword: async () => 'pw',
+        copyToClipboard: async () => {},
+        promptForMasterPassword: async () => 'master',
+        stdout: { write: () => {} },
+        stderr: { write: () => {} }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(savedProfiles).not.toBeNull()
+    const result = savedProfiles
+    expect(result[0].counter).toBe(6)
+  })
+})

--- a/test/cli-args.test.js
+++ b/test/cli-args.test.js
@@ -6,7 +6,10 @@ describe('parseArgs', () => {
     expect(parseArgs(['-p', 'github-main'])).toEqual({
       profileLabel: 'github-main',
       show: false,
-      help: false
+      help: false,
+      bump: null,
+      list: false,
+      save: false
     })
   })
 
@@ -14,7 +17,10 @@ describe('parseArgs', () => {
     expect(parseArgs(['--profile', 'github-main', '--show'])).toEqual({
       profileLabel: 'github-main',
       show: true,
-      help: false
+      help: false,
+      bump: null,
+      list: false,
+      save: false
     })
   })
 
@@ -22,7 +28,32 @@ describe('parseArgs', () => {
     expect(parseArgs(['--help'])).toEqual({
       profileLabel: null,
       show: false,
-      help: true
+      help: true,
+      bump: null,
+      list: false,
+      save: false
+    })
+  })
+
+  it('parses -b <label>', () => {
+    expect(parseArgs(['-b', 'github-main'])).toEqual({
+      profileLabel: null,
+      show: false,
+      help: false,
+      list: false,
+      bump: 'github-main',
+      save: false
+    })
+  })
+
+  it('parses --bump <label> --save --show', () => {
+    expect(parseArgs(['--bump', 'github-main', '--save', '--show'])).toEqual({
+      profileLabel: null,
+      show: true,
+      help: false,
+      list: false,
+      bump: 'github-main',
+      save: true
     })
   })
 

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { runCli } from '../src/cli-runner.js'
-import { DEFAULT_PROFILE } from './fixtures/profiles.js'
+import {DEFAULT_PROFILE, makeProfile} from './fixtures/profiles.js'
 import { makeCliArgs } from './fixtures/cli.js'
 
 describe('runCli', () => {
@@ -85,5 +85,115 @@ describe('runCli', () => {
 
     expect(exitCode).toBe(1)
     expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/profile not found/i))
+  })
+
+  it('does not report saved if save fails', async () => {
+    const profile = makeProfile({ label: 'github', counter: 5 })
+
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ bump: 'github', save: true }),
+      {
+        loadProfileByLabel: async () => profile,
+        loadAllProfiles: async () => [profile],
+        saveProfiles: async () => {
+          throw new Error('disk full')
+        },
+        generatePassword: async () => 'pw',
+        copyToClipboard: async () => {},
+        promptForMasterPassword: async () => 'master',
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(1)
+
+    const output = stdout.write.mock.calls.map(c => c[0]).join('')
+    expect(output).not.toMatch(/\(saved\)/)
+  })
+
+  it('updates updatedAt when saved', async () => {
+    const profile = makeProfile({
+      label: 'github',
+      counter: 5,
+      updatedAt: '2020-01-01T00:00:00.000Z'
+    })
+
+    /** @type {import('../src/profiles-file.js').Profile[] | null} */
+    let savedProfiles = null
+
+    await runCli(
+      makeCliArgs({ bump: 'github', save: true }),
+      {
+        loadProfileByLabel: async () => profile,
+        loadAllProfiles: async () => [profile],
+        saveProfiles: async p => { savedProfiles = p },
+        generatePassword: async () => 'pw',
+        copyToClipboard: async () => {},
+        promptForMasterPassword: async () => 'master',
+        stdout: { write: () => {} },
+        stderr: { write: () => {} }
+      }
+    )
+
+    if (!savedProfiles) throw new Error('not saved')
+
+    /** @type {import('../src/profiles-file.js').Profile} */
+    const savedProfile = savedProfiles[0]
+
+    expect(savedProfile.updatedAt).not.toBe(profile.updatedAt)
+  })
+
+  it('fails if profile does not exist', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ bump: 'nope' }),
+      {
+        loadProfileByLabel: async () => {
+          throw new Error('Profile not found: nope')
+        },
+        stderr,
+        stdout: { write: () => {} }
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/not found/i))
+  })
+
+  it('fails when no command is specified', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs(), // all defaults → no profile, no bump, no list
+      {
+        stderr,
+        stdout: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(
+      expect.stringMatching(/no command/i)
+    )
+  })
+
+  it('treats missing profiles file as empty list', async () => {
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ list: true }),
+      {
+        loadAllProfiles: async () => [],
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringMatching(/no profiles/i))
   })
 })

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { runCli } from '../src/cli-runner.js'
 import { DEFAULT_PROFILE } from './fixtures/profiles.js'
+import { makeCliArgs } from './fixtures/cli.js'
 
 describe('runCli', () => {
   it('loads profile, prompts for password, generates, copies, and prints success', async () => {
@@ -12,7 +13,7 @@ describe('runCli', () => {
     const stderr = { write: vi.fn() }
 
     const exitCode = await runCli(
-      { profileLabel: 'github-main', show: false, help: false },
+      makeCliArgs({ profileLabel: 'github-main', show: false, help: false }),
       {
         loadProfileByLabel,
         promptForMasterPassword,
@@ -35,7 +36,7 @@ describe('runCli', () => {
     const stdout = { write: vi.fn() }
 
     const exitCode = await runCli(
-      { profileLabel: 'github-main', show: true, help: false },
+      makeCliArgs({ profileLabel: 'github-main', show: true, help: false }),
       {
         loadProfileByLabel: async () => DEFAULT_PROFILE,
         promptForMasterPassword: async () => 'master',
@@ -54,7 +55,7 @@ describe('runCli', () => {
     const stdout = { write: vi.fn() }
 
     const exitCode = await runCli(
-      { profileLabel: null, show: false, help: true },
+      makeCliArgs({ profileLabel: null, show: false, help: true }),
       {
         stdout,
         stderr: { write: vi.fn() }
@@ -69,7 +70,7 @@ describe('runCli', () => {
     const stderr = { write: vi.fn() }
 
     const exitCode = await runCli(
-      { profileLabel: 'missing', show: false, help: false },
+      makeCliArgs({ profileLabel: 'missing', show: false, help: false }),
       {
         loadProfileByLabel: async () => {
           throw new Error('Profile not found: missing')

--- a/test/fixtures/cli.js
+++ b/test/fixtures/cli.js
@@ -1,0 +1,11 @@
+export function makeCliArgs(overrides = {}) {
+  return {
+    profileLabel: null,
+    show: false,
+    help: false,
+    list: false,
+    bump: null,
+    save: false,
+    ...overrides
+  }
+}

--- a/test/fixtures/cli.js
+++ b/test/fixtures/cli.js
@@ -1,3 +1,7 @@
+/**
+ * @param {Partial<import('../../src/cli-args.js').CliArgs>=} overrides
+ * @returns {import('../../src/cli-args.js').CliArgs}
+ */
 export function makeCliArgs(overrides = {}) {
   return {
     profileLabel: null,

--- a/test/fixtures/profiles.js
+++ b/test/fixtures/profiles.js
@@ -1,3 +1,5 @@
+/** @typedef {import('../../src/profiles-file.js').Profile} Profile */
+/** @type {Profile} */
 export const DEFAULT_PROFILE = {
   version: 'dpg:v2',
   label: 'github-main',
@@ -6,9 +8,15 @@ export const DEFAULT_PROFILE = {
   counter: 1,
   length: 20,
   require: ['lower', 'upper', 'digit', 'symbol'],
-  symbolSet: '!@#'
+  symbolSet: '!@#',
+  createdAt: '2026-04-12T00:00:00.000Z',
+  updatedAt: '2026-04-12T00:00:00.000Z'
 }
 
+/**
+ * @param {Partial<import('../../src/profiles-file.js').Profile>=} overrides
+ * @returns {Profile}
+ */
 export function makeProfile(overrides = {}) {
   return {
     ...DEFAULT_PROFILE,

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runCli } from '../src/cli-runner.js'
+import { makeProfile } from './fixtures/profiles.js'
+import { makeCliArgs } from './fixtures/cli.js'
+
+describe('list command', () => {
+  it('prints all profiles in sorted order', async () => {
+    const profiles = [
+      makeProfile({ label: 'zeta', service: 'z.com' }),
+      makeProfile({ label: 'alpha', service: 'a.com' })
+    ]
+
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ list: true }),
+      {
+        loadAllProfiles: async () => profiles,
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+
+    const output = stdout.write.mock.calls.map(c => c[0]).join('')
+    expect(output).toMatch(/alpha/)
+    expect(output).toMatch(/zeta/)
+    expect(output.indexOf('alpha')).toBeLessThan(output.indexOf('zeta'))
+  })
+
+  it('prints empty message if no profiles exist', async () => {
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ list: true }),
+      {
+        loadAllProfiles: async () => [],
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringMatching(/no profiles/i))
+  })
+})

--- a/test/profiles-file.test.js
+++ b/test/profiles-file.test.js
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import fs from 'node:fs/promises'
 import { mkdtemp } from 'node:fs/promises'
 import path from 'node:path'
-import { resolveProfilesPath, findProfileByLabel, loadProfileByLabel } from '../src/profiles-file.js'
+import {resolveProfilesPath, findProfileByLabel, loadProfileByLabel, loadAllProfiles} from '../src/profiles-file.js'
 import { makeProfile } from './fixtures/profiles.js'
 
 describe('resolveProfilesPath', () => {
@@ -88,5 +88,11 @@ describe('loadProfileByLabel', () => {
 
     expect(result.label).toBe('gitlab-main')
     expect(result.service).toBe('gitlab.com')
+  })
+
+  it('returns empty array when profiles file is missing', async () => {
+    const missingPath = path.join('/definitely', 'not-there', 'profiles.json')
+    const result = await loadAllProfiles({ profilesPath: missingPath })
+    expect(result).toEqual([])
   })
 })


### PR DESCRIPTION
## DPG-001: Add bump and list commands

Adds initial profile management to the CLI:

- `--list` to inspect available profiles  
- `--bump <label>` to increment counter and generate next password  
- optional `--save` to persist the counter  
- optional `--show` to print the password  

Also introduces atomic profile writes and sorting by label.

Tests added for list and bump (ephemeral + persistent). All passing.