### PR TITLE
DPG-002: add profile creation via --new

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,17 @@ This will:
 
 This also prints the generated password to stdout.
 
+### Create a new profile
+
+    dpg --new github-work
+
+Creates a new profile with sensible defaults.
+
+Rules:
+- label must be unique
+- label may contain only letters, digits, dot, underscore, and hyphen
+- spaces are not allowed
+
 ### List profiles
 
     dpg --list

--- a/src/cli-args.js
+++ b/src/cli-args.js
@@ -85,7 +85,7 @@ export function usageText() {
     '',
     'Options:',
     '  -p, --profile <label>   Generate password from existing profile',
-    '  -n, --new <label>       Generate new profile with default values',
+    '  -n, --new <label>       Create new profile with default values',
     '  -b, --bump <label>      Generate password using counter + 1',
     '      --save              Persist changes made by --bump',
     '      --show              Print generated password to stdout',

--- a/src/cli-args.js
+++ b/src/cli-args.js
@@ -5,7 +5,8 @@
  *   help: boolean,
  *   list: boolean,
  *   bump: string | null,
- *   save: boolean
+ *   save: boolean,
+ *   create: string | null
  * }} CliArgs
  */
 
@@ -17,7 +18,8 @@
  *   help: boolean,
  *   list: boolean,
  *   bump: string | null,
- *   save: boolean
+ *   save: boolean,
+ *   create: string | null
  * }}
  */
 export function parseArgs(argv) {
@@ -27,6 +29,7 @@ export function parseArgs(argv) {
   let list = false
   let bump = null
   let save = false
+  let create = null
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
@@ -37,6 +40,12 @@ export function parseArgs(argv) {
         throw new Error('Missing profile label after -p/--profile')
       }
       profileLabel = next
+    } else if (arg === '-n' || arg === '--new') {
+      const next = argv[++i]
+      if (!next) {
+        throw new Error('Missing profile label after -n/--new')
+      }
+      create = next
     } else if (arg === '-b' || arg === '--bump') {
       const next = argv[++i]
       if (!next) {
@@ -56,7 +65,7 @@ export function parseArgs(argv) {
     }
   }
 
-  return { profileLabel, show, help, list, bump, save }
+  return { profileLabel, show, help, list, bump, save, create }
 }
 
 export function usageText() {
@@ -65,6 +74,8 @@ export function usageText() {
     '  dpg -p <label>',
     '  dpg --profile <label>',
     '  dpg -p <label> --show',
+    '  dpg -n <label>',
+    '  dpg --new <label>',
     '  dpg --list',
     '  dpg -b <label>',
     '  dpg -b <label> --show',
@@ -74,6 +85,7 @@ export function usageText() {
     '',
     'Options:',
     '  -p, --profile <label>   Generate password from existing profile',
+    '  -n, --new <label>       Generate new profile with default values',
     '  -b, --bump <label>      Generate password using counter + 1',
     '      --save              Persist changes made by --bump',
     '      --show              Print generated password to stdout',

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -1,4 +1,5 @@
 import {loadProfileByLabel, saveProfiles, loadAllProfiles} from './profiles-file.js'
+import { createDefaultProfile } from './profile-factory.js'
 import {promptForMasterPassword} from './prompt.js'
 import {generatePassword} from './generate.js'
 import {copyToClipboard} from './clipboard.js'
@@ -39,8 +40,8 @@ export async function runCli(args, deps = {}) {
     return 0
   }
 
-  if (!args.profileLabel && !args.bump && !args.list) {
-    stderr.write('No command specified. Use -p <label>, -b <label>, or --list. See -h for help.\n')
+  if (!args.profileLabel && !args.bump && !args.create && !args.list) {
+    stderr.write('No command specified. Use -p <label>, -b <label>, -n <label>, or --list. See -h for help.\n')
     return 1
   }
 
@@ -105,6 +106,21 @@ export async function runCli(args, deps = {}) {
         stdout.write(`Counter: ${oldCounter} → ${newCounter}\n`)
       }
 
+      return 0
+    }
+
+    if (args.create) {
+      const all = await loadAll()
+
+      if (all.some(p => p.label === args.create)) {
+        stderr.write(`Profile '${args.create}' already exists\n`)
+        return 1
+      }
+
+      const profile = createDefaultProfile(args.create)
+      await save([...all, profile])
+
+      stdout.write(`Created profile '${args.create}'\n`)
       return 0
     }
 

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -113,14 +113,14 @@ export async function runCli(args, deps = {}) {
       const all = await loadAll()
 
       if (all.some(p => p.label === args.create)) {
-        stderr.write(`Profile '${args.create}' already exists\n`)
+        stderr.write(`Profile already exists: '${args.create}'\n`)
         return 1
       }
 
       const profile = createDefaultProfile(args.create)
       await save([...all, profile])
 
-      stdout.write(`Created profile '${args.create}'\n`)
+      stdout.write(`Created profile: '${args.create}'\n`)
       return 0
     }
 

--- a/src/profile-factory.js
+++ b/src/profile-factory.js
@@ -1,0 +1,21 @@
+import { validateProfileLabel } from './profile-validation.js'
+
+/**
+ * @param {string} label
+ * @param {string=} now
+ */
+export function createDefaultProfile(label, now = new Date().toISOString()) {
+  validateProfileLabel(label)
+
+  return {
+    version: 'dpg:v2',
+    label,
+    service: label,
+    counter: 0,
+    length: 20,
+    require: ['lower', 'upper', 'digit', 'symbol'],
+    symbolSet: '!@#',
+    createdAt: now,
+    updatedAt: now
+  }
+}

--- a/src/profile-factory.js
+++ b/src/profile-factory.js
@@ -1,5 +1,7 @@
 import { validateProfileLabel } from './profile-validation.js'
 
+export const DEFAULT_REQUIRE = ['lower', 'upper', 'digit', 'symbol']
+export const DEFAULT_SYMBOL_SET = '!@#'
 /**
  * @param {string} label
  * @param {string=} now
@@ -13,8 +15,8 @@ export function createDefaultProfile(label, now = new Date().toISOString()) {
     service: label,
     counter: 0,
     length: 20,
-    require: ['lower', 'upper', 'digit', 'symbol'],
-    symbolSet: '!@#',
+    require: DEFAULT_REQUIRE,
+    symbolSet: DEFAULT_SYMBOL_SET,
     createdAt: now,
     updatedAt: now
   }

--- a/src/profile-validation.js
+++ b/src/profile-validation.js
@@ -1,0 +1,15 @@
+const PROFILE_LABEL_RE = /^[A-Za-z0-9._-]+$/
+
+/**
+ * @param {string} label
+ * @returns {true}
+ */
+export function validateProfileLabel(label) {
+  if (!label || !PROFILE_LABEL_RE.test(label)) {
+    throw new Error(
+      `Invalid profile label: '${label}'. Labels may contain only letters, digits, dot, underscore, and hyphen.`
+    )
+  }
+
+  return true
+}

--- a/test/cli-args.test.js
+++ b/test/cli-args.test.js
@@ -9,7 +9,8 @@ describe('parseArgs', () => {
       help: false,
       bump: null,
       list: false,
-      save: false
+      save: false,
+      create: null
     })
   })
 
@@ -20,8 +21,37 @@ describe('parseArgs', () => {
       help: false,
       bump: null,
       list: false,
-      save: false
+      save: false,
+      create: null
     })
+  })
+
+  it('parses -n <label>', () => {
+    expect(parseArgs(['-n', 'github-main'])).toEqual({
+      profileLabel: null,
+      show: false,
+      help: false,
+      list: false,
+      bump: null,
+      save: false,
+      create: 'github-main'
+    })
+  })
+
+  it('parses --new <label>', () => {
+    expect(parseArgs(['--new', 'github-main'])).toEqual({
+      profileLabel: null,
+      show: false,
+      help: false,
+      list: false,
+      bump: null,
+      save: false,
+      create: 'github-main'
+    })
+  })
+
+  it('throws if label is missing after -n/--new', () => {
+    expect(() => parseArgs(['-n'])).toThrow(/label/i)
   })
 
   it('parses --help', () => {
@@ -31,7 +61,8 @@ describe('parseArgs', () => {
       help: true,
       bump: null,
       list: false,
-      save: false
+      save: false,
+      create: null
     })
   })
 
@@ -42,7 +73,8 @@ describe('parseArgs', () => {
       help: false,
       list: false,
       bump: 'github-main',
-      save: false
+      save: false,
+      create: null
     })
   })
 
@@ -53,7 +85,8 @@ describe('parseArgs', () => {
       help: false,
       list: false,
       bump: 'github-main',
-      save: true
+      save: true,
+      create: null
     })
   })
 

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -3,6 +3,10 @@ import { runCli } from '../src/cli-runner.js'
 import {DEFAULT_PROFILE, makeProfile} from './fixtures/profiles.js'
 import { makeCliArgs } from './fixtures/cli.js'
 import {createDefaultProfile} from "../src/profile-factory.js";
+import fs from 'node:fs/promises'
+import path from "node:path";
+import {tmpdir} from "node:os";
+import {loadAllProfiles, saveProfiles} from "../src/profiles-file.js";
 
 describe('runCli', () => {
   it('loads profile, prompts for password, generates, copies, and prints success', async () => {
@@ -71,12 +75,16 @@ describe('runCli', () => {
     expect(exitCode).toBe(0)
 
     if (!savedProfiles) throw new Error('not saved')
+    expect(savedProfiles).toHaveLength(1)
+
     /** @type {import('../src/profiles-file.js').Profile} */
     const savedProfile = savedProfiles[0]
-
-    expect(savedProfiles).toHaveLength(1)
     expect(savedProfile.label).toBe('github-main')
-    expect(stdout.write).toHaveBeenCalledWith("Created profile 'github-main'\n")
+    expect(savedProfile.service).toBe('github-main')
+    expect(savedProfile.counter).toBe(0)
+    expect(savedProfile.require.length).toBe(4)
+    expect(savedProfile.length).toBe(20)
+    expect(stdout.write).toHaveBeenCalledWith("Created profile: 'github-main'\n")
   })
 
   it('fails when creating a duplicate profile', async () => {
@@ -257,5 +265,32 @@ describe('runCli', () => {
 
     expect(exitCode).toBe(0)
     expect(stdout.write).toHaveBeenCalledWith(expect.stringMatching(/no profiles/i))
+  })
+
+  it('creates a profile when the profiles file does not exist', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'dpg-'))
+    const profilesPath = path.join(dir, 'profiles.json')
+
+    const stdout = { write: vi.fn() }
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ create: 'github-main' }),
+      {
+        loadAllProfiles: () => loadAllProfiles({ profilesPath }),
+        saveProfiles: profiles => saveProfiles(profiles, { profilesPath }),
+        stdout,
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stdout.write).toHaveBeenCalledWith("Created profile: 'github-main'\n")
+    expect(stderr.write).not.toHaveBeenCalled()
+
+    const saved = JSON.parse(await fs.readFile(profilesPath, 'utf8'))
+    expect(saved).toHaveLength(1)
+    expect(saved[0].label).toBe('github-main')
+    expect(saved[0].counter).toBe(0)
   })
 })

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { runCli } from '../src/cli-runner.js'
 import {DEFAULT_PROFILE, makeProfile} from './fixtures/profiles.js'
 import { makeCliArgs } from './fixtures/cli.js'
+import {createDefaultProfile} from "../src/profile-factory.js";
 
 describe('runCli', () => {
   it('loads profile, prompts for password, generates, copies, and prints success', async () => {
@@ -49,6 +50,67 @@ describe('runCli', () => {
 
     expect(exitCode).toBe(0)
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('generated-secret'))
+  })
+
+  it('creates a new profile', async () => {
+
+    /** @type {import('../src/profiles-file.js').Profile[] | null} */
+    let savedProfiles = null
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ create: 'github-main' }),
+      {
+        loadAllProfiles: async () => [],
+        saveProfiles: async profiles => { savedProfiles = profiles },
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+
+    if (!savedProfiles) throw new Error('not saved')
+    /** @type {import('../src/profiles-file.js').Profile} */
+    const savedProfile = savedProfiles[0]
+
+    expect(savedProfiles).toHaveLength(1)
+    expect(savedProfile.label).toBe('github-main')
+    expect(stdout.write).toHaveBeenCalledWith("Created profile 'github-main'\n")
+  })
+
+  it('fails when creating a duplicate profile', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ create: 'github-main' }),
+      {
+        loadAllProfiles: async () => [makeProfile({ label: 'github-main' })],
+        saveProfiles: async () => {},
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/already exists/i))
+  })
+
+  it('new profile is visible in list output', async () => {
+    const created = createDefaultProfile('github-main', '2026-04-14T12:00:00.000Z')
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ list: true }),
+      {
+        loadAllProfiles: async () => [created],
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringMatching(/github-main/))
   })
 
   it('prints help and exits 0', async () => {

--- a/test/fixtures/cli.js
+++ b/test/fixtures/cli.js
@@ -10,6 +10,7 @@ export function makeCliArgs(overrides = {}) {
     list: false,
     bump: null,
     save: false,
+    create: null,
     ...overrides
   }
 }

--- a/test/profile-factory.test.js
+++ b/test/profile-factory.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createDefaultProfile } from '../src/profile-factory.js'
+import {createDefaultProfile, DEFAULT_REQUIRE, DEFAULT_SYMBOL_SET} from '../src/profile-factory.js'
 
 describe('createDefaultProfile', () => {
   it('creates a valid default profile', () => {
@@ -11,8 +11,8 @@ describe('createDefaultProfile', () => {
       service: 'github-main',
       counter: 0,
       length: 20,
-      require: ['lower', 'upper', 'digit', 'symbol'],
-      symbolSet: '!@#',
+      require: DEFAULT_REQUIRE,
+      symbolSet: DEFAULT_SYMBOL_SET,
       createdAt: '2026-04-14T12:00:00.000Z',
       updatedAt: '2026-04-14T12:00:00.000Z'
     })

--- a/test/profile-factory.test.js
+++ b/test/profile-factory.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { createDefaultProfile } from '../src/profile-factory.js'
+
+describe('createDefaultProfile', () => {
+  it('creates a valid default profile', () => {
+    const profile = createDefaultProfile('github-main', '2026-04-14T12:00:00.000Z')
+
+    expect(profile).toEqual({
+      version: 'dpg:v2',
+      label: 'github-main',
+      service: 'github-main',
+      counter: 0,
+      length: 20,
+      require: ['lower', 'upper', 'digit', 'symbol'],
+      symbolSet: '!@#',
+      createdAt: '2026-04-14T12:00:00.000Z',
+      updatedAt: '2026-04-14T12:00:00.000Z'
+    })
+  })
+})

--- a/test/profile-validation.test.js
+++ b/test/profile-validation.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { validateProfileLabel } from '../src/profile-validation.js'
+
+describe('validateProfileLabel', () => {
+  it('accepts simple labels', () => {
+    expect(validateProfileLabel('github-main')).toBe(true)
+    expect(validateProfileLabel('github_main')).toBe(true)
+    expect(validateProfileLabel('github.main')).toBe(true)
+    expect(validateProfileLabel('GitHub-2026')).toBe(true)
+  })
+
+  it('rejects empty labels', () => {
+    expect(() => validateProfileLabel('')).toThrow(/invalid profile label/i)
+  })
+
+  it('rejects labels with forbidden characters', () => {
+    expect(() => validateProfileLabel('Gïthüb-mäin')).toThrow(/invalid profile label/i)
+  })
+
+  it('rejects labels with spaces', () => {
+    expect(() => validateProfileLabel('github main')).toThrow(/invalid profile label/i)
+  })
+})


### PR DESCRIPTION
feat(DPG-002): add profile creation via --new

- add -n/--new <label> to create profiles with default values
- validate label (no spaces, restricted charset)
- reject duplicate profile labels
- create profiles with sensible defaults and timestamps
- persist via atomic write (creates file if missing)
- integrate with --list and --bump flows
- add validation, factory, and CLI flow tests

Small UX polish:
- consistent error handling (no throw/catch anti-pattern)
- improved CLI messages