### PR TITLE
DPG-003: add profile deletion via --delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ Rules:
 - label may contain only letters, digits, dot, underscore, and hyphen
 - spaces are not allowed
 
+### Delete a profile
+
+    dpg -D github-main
+
+Prompts for confirmation before deleting the profile.
+
+Only an explicit `y` confirms deletion. Any other response cancels it.
+
 ### List profiles
 
     dpg --list

--- a/src/cli-args.js
+++ b/src/cli-args.js
@@ -6,7 +6,8 @@
  *   list: boolean,
  *   bump: string | null,
  *   save: boolean,
- *   create: string | null
+ *   create: string | null,
+ *   deleteLabel: string | null
  * }} CliArgs
  */
 
@@ -19,7 +20,8 @@
  *   list: boolean,
  *   bump: string | null,
  *   save: boolean,
- *   create: string | null
+ *   create: string | null,
+ *   deleteLabel: string | null
  * }}
  */
 export function parseArgs(argv) {
@@ -30,6 +32,7 @@ export function parseArgs(argv) {
   let bump = null
   let save = false
   let create = null
+  let deleteLabel = null
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
@@ -52,6 +55,12 @@ export function parseArgs(argv) {
         throw new Error('Missing profile label after -b/--bump')
       }
       bump = next
+    } else if (arg === '-D' || arg === '--delete') {
+      const next = argv[++i]
+      if (!next) {
+        throw new Error('Missing profile label after -D/--delete')
+      }
+      deleteLabel = next
     } else if (arg === '--list') {
       list = true
     } else if (arg === '--save') {
@@ -65,7 +74,7 @@ export function parseArgs(argv) {
     }
   }
 
-  return { profileLabel, show, help, list, bump, save, create }
+  return { profileLabel, show, help, list, bump, save, create, deleteLabel }
 }
 
 export function usageText() {
@@ -76,6 +85,8 @@ export function usageText() {
     '  dpg -p <label> --show',
     '  dpg -n <label>',
     '  dpg --new <label>',
+    '  dpg -D <label>',
+    '  dpg --delete <label>',
     '  dpg --list',
     '  dpg -b <label>',
     '  dpg -b <label> --show',
@@ -86,6 +97,7 @@ export function usageText() {
     'Options:',
     '  -p, --profile <label>   Generate password from existing profile',
     '  -n, --new <label>       Create new profile with default values',
+    '  -D, --delete <label>    Delete an existing profile (confirmation required)',
     '  -b, --bump <label>      Generate password using counter + 1',
     '      --save              Persist changes made by --bump',
     '      --show              Print generated password to stdout',

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -4,6 +4,7 @@ import {promptForMasterPassword} from './prompt.js'
 import {generatePassword} from './generate.js'
 import {copyToClipboard} from './clipboard.js'
 import {usageText} from './cli-args.js'
+import { promptForConfirmation } from './confirm.js'
 
 /**
  * @typedef {{
@@ -13,6 +14,7 @@ import {usageText} from './cli-args.js'
  *   promptForMasterPassword?: () => Promise<string>,
  *   generatePassword?: (master: string, profile: any) => Promise<string>,
  *   copyToClipboard?: (text: string) => Promise<void>,
+ *   promptForConfirmation?: (prompt: string) => Promise<string>,
  *   stdout?: { write: (s: string) => void },
  *   stderr?: { write: (s: string) => void }
  * }} CliDeps
@@ -31,6 +33,7 @@ export async function runCli(args, deps = {}) {
     promptForMasterPassword: prompt = promptForMasterPassword,
     generatePassword: generate = generatePassword,
     copyToClipboard: copy = copyToClipboard,
+    promptForConfirmation: confirm = promptForConfirmation,
     stdout = process.stdout,
     stderr = process.stderr
   } = deps
@@ -40,8 +43,8 @@ export async function runCli(args, deps = {}) {
     return 0
   }
 
-  if (!args.profileLabel && !args.bump && !args.create && !args.list) {
-    stderr.write('No command specified. Use -p <label>, -b <label>, -n <label>, or --list. See -h for help.\n')
+  if (!args.profileLabel && !args.bump && !args.create && !args.deleteLabel && !args.list) {
+    stderr.write('No command specified. Use -p <label>, -b <label>, -n <label>, -D <label>, or --list. See -h for help.\n')
     return 1
   }
 
@@ -121,6 +124,31 @@ export async function runCli(args, deps = {}) {
       await save([...all, profile])
 
       stdout.write(`Created profile: '${args.create}'\n`)
+      return 0
+    }
+
+    if (args.deleteLabel) {
+      const all = await loadAll()
+      const existing = all.find(p => p.label === args.deleteLabel)
+
+      if (!existing) {
+        stderr.write(`Profile does not exist: '${args.deleteLabel}'\n`)
+        return 1
+      }
+
+      const answer = await confirm(
+        `Delete profile '${args.deleteLabel}'? This cannot be undone. (y/N) `
+      )
+
+      if (answer !== 'y') {
+        stdout.write('Cancelled\n')
+        return 0
+      }
+
+      const remaining = all.filter(p => p.label !== args.deleteLabel)
+      await save(remaining)
+
+      stdout.write(`Deleted profile: '${args.deleteLabel}'\n`)
       return 0
     }
 

--- a/src/confirm.js
+++ b/src/confirm.js
@@ -1,0 +1,24 @@
+import readline from 'node:readline'
+
+/**
+ * @param {string} prompt
+ * @returns {Promise<string>}
+ */
+export function promptForConfirmation(prompt) {
+  return new Promise((resolve, reject) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    })
+
+    rl.question(prompt, answer => {
+      rl.close()
+      resolve(answer)
+    })
+
+    rl.on('SIGINT', () => {
+      rl.close()
+      reject(new Error('Prompt cancelled'))
+    })
+  })
+}

--- a/test/cli-args.test.js
+++ b/test/cli-args.test.js
@@ -10,7 +10,8 @@ describe('parseArgs', () => {
       bump: null,
       list: false,
       save: false,
-      create: null
+      create: null,
+      deleteLabel: null
     })
   })
 
@@ -22,7 +23,8 @@ describe('parseArgs', () => {
       bump: null,
       list: false,
       save: false,
-      create: null
+      create: null,
+      deleteLabel: null
     })
   })
 
@@ -34,7 +36,8 @@ describe('parseArgs', () => {
       list: false,
       bump: null,
       save: false,
-      create: 'github-main'
+      create: 'github-main',
+      deleteLabel: null
     })
   })
 
@@ -46,12 +49,43 @@ describe('parseArgs', () => {
       list: false,
       bump: null,
       save: false,
-      create: 'github-main'
+      create: 'github-main',
+      deleteLabel: null
     })
   })
 
   it('throws if label is missing after -n/--new', () => {
     expect(() => parseArgs(['-n'])).toThrow(/label/i)
+  })
+
+  it('parses -D <label>', () => {
+    expect(parseArgs(['-D', 'github-main'])).toEqual({
+      profileLabel: null,
+      show: false,
+      help: false,
+      list: false,
+      bump: null,
+      save: false,
+      create: null,
+      deleteLabel: 'github-main'
+    })
+  })
+
+  it('parses --delete <label>', () => {
+    expect(parseArgs(['--delete', 'github-main'])).toEqual({
+      profileLabel: null,
+      show: false,
+      help: false,
+      list: false,
+      bump: null,
+      save: false,
+      create: null,
+      deleteLabel: 'github-main'
+    })
+  })
+
+  it('throws if label is missing after -D/--delete', () => {
+    expect(() => parseArgs(['-D'])).toThrow(/label/i)
   })
 
   it('parses --help', () => {
@@ -62,7 +96,8 @@ describe('parseArgs', () => {
       bump: null,
       list: false,
       save: false,
-      create: null
+      create: null,
+      deleteLabel: null
     })
   })
 
@@ -74,7 +109,8 @@ describe('parseArgs', () => {
       list: false,
       bump: 'github-main',
       save: false,
-      create: null
+      create: null,
+      deleteLabel: null
     })
   })
 
@@ -86,7 +122,8 @@ describe('parseArgs', () => {
       list: false,
       bump: 'github-main',
       save: true,
-      create: null
+      create: null,
+      deleteLabel: null
     })
   })
 

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -293,4 +293,95 @@ describe('runCli', () => {
     expect(saved[0].label).toBe('github-main')
     expect(saved[0].counter).toBe(0)
   })
+
+  it('deletes an existing profile after confirmation', async () => {
+    const profiles = [
+      makeProfile({ label: 'github-main' }),
+      makeProfile({ label: 'gitlab-main', service: 'gitlab.com' })
+    ]
+
+    /** @type {import('../src/profiles-file.js').Profile[] | null} */
+    let savedProfiles = null
+
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ deleteLabel: 'github-main' }),
+      {
+        loadAllProfiles: async () => profiles,
+        saveProfiles: async p => { savedProfiles = p },
+        promptForConfirmation: async () => 'y',
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(savedProfiles).not.toBeNull()
+
+    if (!savedProfiles) throw new Error('not saved')
+
+    expect(savedProfiles).toHaveLength(1)
+    expect(savedProfiles[0].label).toBe('gitlab-main')
+    expect(stdout.write).toHaveBeenCalledWith("Deleted profile: 'github-main'\n")
+  })
+
+  it('cancels deletion on default response', async () => {
+    const profiles = [makeProfile({ label: 'github-main' })]
+    let saveCalled = false
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ deleteLabel: 'github-main' }),
+      {
+        loadAllProfiles: async () => profiles,
+        saveProfiles: async () => { saveCalled = true },
+        promptForConfirmation: async () => '',
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(saveCalled).toBe(false)
+    expect(stdout.write).toHaveBeenCalledWith('Cancelled\n')
+  })
+
+  it('cancels deletion on non-y response', async () => {
+    const profiles = [makeProfile({ label: 'github-main' })]
+    let saveCalled = false
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ deleteLabel: 'github-main' }),
+      {
+        loadAllProfiles: async () => profiles,
+        saveProfiles: async () => { saveCalled = true },
+        promptForConfirmation: async () => 'n',
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(saveCalled).toBe(false)
+    expect(stdout.write).toHaveBeenCalledWith('Cancelled\n')
+  })
+
+  it('fails when deleting a non-existent profile', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ deleteLabel: 'missing' }),
+      {
+        loadAllProfiles: async () => [makeProfile({ label: 'github-main' })],
+        promptForConfirmation: async () => 'y',
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
+  })
 })

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -384,4 +384,36 @@ describe('runCli', () => {
     expect(exitCode).toBe(1)
     expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
   })
+
+  it('does not report deletion if save fails after confirmation', async () => {
+    const profiles = [
+      makeProfile({ label: 'github-main' }),
+      makeProfile({ label: 'gitlab-main', service: 'gitlab.com' })
+    ]
+
+    const stdout = { write: vi.fn() }
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ deleteLabel: 'github-main' }),
+      {
+        loadAllProfiles: async () => profiles,
+        saveProfiles: async () => {
+          throw new Error('disk full')
+        },
+        promptForConfirmation: async () => 'y',
+        stdout,
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+
+    const out = stdout.write.mock.calls.map(c => c[0]).join('')
+    expect(out).not.toMatch(/Deleted profile/i)
+
+    expect(stderr.write).toHaveBeenCalledWith(
+      expect.stringMatching(/disk full/i)
+    )
+  })
 })

--- a/test/fixtures/cli.js
+++ b/test/fixtures/cli.js
@@ -11,6 +11,7 @@ export function makeCliArgs(overrides = {}) {
     bump: null,
     save: false,
     create: null,
+    deleteLabel: null,
     ...overrides
   }
 }


### PR DESCRIPTION
Adds profile deletion to the CLI.

- `-D/--delete <label>` removes a profile after confirmation
- requires explicit `y` (default is no)
- persists changes atomically

Includes tests for:
- successful deletion
- cancellation paths
- non-existent profile

No regression in existing commands.