### PR TITLE
DPG-004: Show profile (`--show-profile`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ This does the same thing, but also persists the incremented counter back to `pro
 
 This also prints the generated password to stdout.
 
+### Show a profile
+
+    dpg --show-profile github-main
+
+Prints the full profile as pretty-printed JSON.
+
+Useful for:
+- debugging
+- verifying stored fields
+- piping into tools such as `jq`
+
 ### Help
 
     dpg --help

--- a/src/cli-args.js
+++ b/src/cli-args.js
@@ -7,24 +7,14 @@
  *   bump: string | null,
  *   save: boolean,
  *   create: string | null,
- *   deleteLabel: string | null
- *   showProfileLabel: string | null,
+ *   deleteLabel: string | null,
+ *   showProfileLabel: string | null
  * }} CliArgs
  */
 
 /**
  * @param {string[]} argv
- * @returns {{
- *   profileLabel: string | null,
- *   show: boolean,
- *   help: boolean,
- *   list: boolean,
- *   bump: string | null,
- *   save: boolean,
- *   create: string | null,
- *   deleteLabel: string | null,
- *   showProfileLabel: string | null
- * }}
+ * @returns {CliArgs}
  */
 export function parseArgs(argv) {
   let profileLabel = null
@@ -92,25 +82,27 @@ export function usageText() {
     '  dpg -p <label>',
     '  dpg --profile <label>',
     '  dpg -p <label> --show',
-    '  dpg -n <label>',
-    '  dpg --new <label>',
-    '  dpg -D <label>',
-    '  dpg --delete <label>',
     '  dpg --list',
     '  dpg -b <label>',
     '  dpg -b <label> --show',
     '  dpg -b <label> --save',
     '  dpg -b <label> --save --show',
+    '  dpg -n <label>',
+    '  dpg --new <label>',
+    '  dpg -D <label>',
+    '  dpg --delete <label>',
+    '  dpg --show-profile <label>',
     '  dpg --help',
     '',
     'Options:',
-    '  -p, --profile <label>   Generate password from existing profile',
-    '  -n, --new <label>       Create new profile with default values',
-    '  -D, --delete <label>    Delete an existing profile (confirmation required)',
-    '  -b, --bump <label>      Generate password using counter + 1',
-    '      --save              Persist changes made by --bump',
-    '      --show              Print generated password to stdout',
-    '      --list              List available profiles',
-    '  -h, --help              Show this help text'
+    '  -p, --profile <label>       Generate password from existing profile',
+    '  -b, --bump <label>          Generate password using counter + 1',
+    '      --save                  Persist changes made by --bump',
+    '      --show                  Print generated password to stdout',
+    '      --list                  List available profiles',
+    '  -n, --new <label>           Create a new profile with default values',
+    '  -D, --delete <label>        Delete an existing profile (confirmation required)',
+    '      --show-profile <label>  Pretty-print a profile as JSON',
+    '  -h, --help                  Show this help text'
   ].join('\n')
 }

--- a/src/cli-args.js
+++ b/src/cli-args.js
@@ -8,6 +8,7 @@
  *   save: boolean,
  *   create: string | null,
  *   deleteLabel: string | null
+ *   showProfileLabel: string | null,
  * }} CliArgs
  */
 
@@ -21,7 +22,8 @@
  *   bump: string | null,
  *   save: boolean,
  *   create: string | null,
- *   deleteLabel: string | null
+ *   deleteLabel: string | null,
+ *   showProfileLabel: string | null
  * }}
  */
 export function parseArgs(argv) {
@@ -33,6 +35,7 @@ export function parseArgs(argv) {
   let save = false
   let create = null
   let deleteLabel = null
+  let showProfileLabel = null
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
@@ -61,6 +64,12 @@ export function parseArgs(argv) {
         throw new Error('Missing profile label after -D/--delete')
       }
       deleteLabel = next
+    } else if (arg === '--show-profile') {
+      const next = argv[++i]
+      if (!next) {
+        throw new Error('Missing profile label after --show-profile')
+      }
+      showProfileLabel = next
     } else if (arg === '--list') {
       list = true
     } else if (arg === '--save') {
@@ -74,7 +83,7 @@ export function parseArgs(argv) {
     }
   }
 
-  return { profileLabel, show, help, list, bump, save, create, deleteLabel }
+  return { profileLabel, show, help, list, bump, save, create, deleteLabel, showProfileLabel }
 }
 
 export function usageText() {

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -1,10 +1,11 @@
-import {loadProfileByLabel, saveProfiles, loadAllProfiles} from './profiles-file.js'
+import { loadProfileByLabel, saveProfiles, loadAllProfiles } from './profiles-file.js'
 import { createDefaultProfile } from './profile-factory.js'
-import {promptForMasterPassword} from './prompt.js'
-import {generatePassword} from './generate.js'
-import {copyToClipboard} from './clipboard.js'
-import {usageText} from './cli-args.js'
+import { promptForMasterPassword } from './prompt.js'
+import { generatePassword } from './generate.js'
+import { copyToClipboard } from './clipboard.js'
+import { usageText } from './cli-args.js'
 import { promptForConfirmation } from './confirm.js'
+import { serializeProfilePretty } from './profile-serialization.js'
 
 /**
  * @typedef {{
@@ -43,8 +44,8 @@ export async function runCli(args, deps = {}) {
     return 0
   }
 
-  if (!args.profileLabel && !args.bump && !args.create && !args.deleteLabel && !args.list) {
-    stderr.write('No command specified. Use -p <label>, -b <label>, -n <label>, -D <label>, or --list. See -h for help.\n')
+  if (!args.profileLabel && !args.bump && !args.list && !args.create && !args.deleteLabel && !args.showProfileLabel) {
+    stderr.write('No command specified. Use -p <label>, -b <label>, --list, -n <label>, -D <label>, or --show-profile <label>. See -h for help.\n')
     return 1
   }
 
@@ -149,6 +150,12 @@ export async function runCli(args, deps = {}) {
       await save(remaining)
 
       stdout.write(`Deleted profile: '${args.deleteLabel}'\n`)
+      return 0
+    }
+
+    if (args.showProfileLabel) {
+      const profile = await load(args.showProfileLabel)
+      stdout.write(serializeProfilePretty(profile) + '\n')
       return 0
     }
 

--- a/src/profile-serialization.js
+++ b/src/profile-serialization.js
@@ -1,0 +1,48 @@
+const PROFILE_FIELD_ORDER = [
+  'version',
+  'label',
+  'service',
+  'account',
+  'counter',
+  'length',
+  'require',
+  'symbolSet',
+  'notes',
+  'createdAt',
+  'updatedAt'
+]
+
+/**
+ * @typedef {import('./profiles-file.js').Profile} Profile
+ */
+
+/**
+ * @param {Profile} profile
+ * @returns {Profile}
+ */
+export function normalizeProfileFieldOrder(profile) {
+  /** @type {Record<string, any>} */
+  const ordered = {}
+
+  for (const key of PROFILE_FIELD_ORDER) {
+    if (key in profile) {
+      ordered[key] = profile[key]
+    }
+  }
+
+  for (const [key, value] of Object.entries(profile)) {
+    if (!(key in ordered)) {
+      ordered[key] = value
+    }
+  }
+
+  return /** @type {Profile} */ (ordered)
+}
+
+/**
+ * @param {Profile} profile
+ * @returns {string}
+ */
+export function serializeProfilePretty(profile) {
+  return JSON.stringify(normalizeProfileFieldOrder(profile), null, 2)
+}

--- a/test/cli-args.test.js
+++ b/test/cli-args.test.js
@@ -11,7 +11,8 @@ describe('parseArgs', () => {
       list: false,
       save: false,
       create: null,
-      deleteLabel: null
+      deleteLabel: null,
+      showProfileLabel: null
     })
   })
 
@@ -24,8 +25,13 @@ describe('parseArgs', () => {
       list: false,
       save: false,
       create: null,
-      deleteLabel: null
+      deleteLabel: null,
+      showProfileLabel: null
     })
+  })
+
+  it('throws if profile label is missing', () => {
+    expect(() => parseArgs(['-p'])).toThrow(/profile label/i)
   })
 
   it('parses -n <label>', () => {
@@ -37,7 +43,8 @@ describe('parseArgs', () => {
       bump: null,
       save: false,
       create: 'github-main',
-      deleteLabel: null
+      deleteLabel: null,
+      showProfileLabel: null
     })
   })
 
@@ -50,7 +57,8 @@ describe('parseArgs', () => {
       bump: null,
       save: false,
       create: 'github-main',
-      deleteLabel: null
+      deleteLabel: null,
+      showProfileLabel: null
     })
   })
 
@@ -67,7 +75,8 @@ describe('parseArgs', () => {
       bump: null,
       save: false,
       create: null,
-      deleteLabel: 'github-main'
+      deleteLabel: 'github-main',
+      showProfileLabel: null
     })
   })
 
@@ -80,25 +89,13 @@ describe('parseArgs', () => {
       bump: null,
       save: false,
       create: null,
-      deleteLabel: 'github-main'
+      deleteLabel: 'github-main',
+      showProfileLabel: null
     })
   })
 
   it('throws if label is missing after -D/--delete', () => {
     expect(() => parseArgs(['-D'])).toThrow(/label/i)
-  })
-
-  it('parses --help', () => {
-    expect(parseArgs(['--help'])).toEqual({
-      profileLabel: null,
-      show: false,
-      help: true,
-      bump: null,
-      list: false,
-      save: false,
-      create: null,
-      deleteLabel: null
-    })
   })
 
   it('parses -b <label>', () => {
@@ -110,7 +107,8 @@ describe('parseArgs', () => {
       bump: 'github-main',
       save: false,
       create: null,
-      deleteLabel: null
+      deleteLabel: null,
+      showProfileLabel: null
     })
   })
 
@@ -123,12 +121,41 @@ describe('parseArgs', () => {
       bump: 'github-main',
       save: true,
       create: null,
-      deleteLabel: null
+      deleteLabel: null,
+      showProfileLabel: null
     })
   })
 
-  it('throws if profile label is missing', () => {
-    expect(() => parseArgs(['-p'])).toThrow(/profile label/i)
+  it('parses --show-profile <label>', () => {
+    expect(parseArgs(['--show-profile', 'github-main'])).toEqual({
+      profileLabel: null,
+      show: false,
+      help: false,
+      list: false,
+      bump: null,
+      save: false,
+      create: null,
+      deleteLabel: null,
+      showProfileLabel: 'github-main'
+    })
+  })
+
+  it('throws if label is missing after --show-profile', () => {
+    expect(() => parseArgs(['--show-profile'])).toThrow(/label/i)
+  })
+
+  it('parses --help', () => {
+    expect(parseArgs(['--help'])).toEqual({
+      profileLabel: null,
+      show: false,
+      help: true,
+      bump: null,
+      list: false,
+      save: false,
+      create: null,
+      deleteLabel: null,
+      showProfileLabel: null
+    })
   })
 
   it('throws on unknown argument', () => {

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -416,4 +416,45 @@ describe('runCli', () => {
       expect.stringMatching(/disk full/i)
     )
   })
+
+  it('shows an existing profile as pretty-printed JSON', async () => {
+    const profile = makeProfile({ label: 'github-main', service: 'github.com' })
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ showProfileLabel: 'github-main' }),
+      {
+        loadProfileByLabel: async () => profile,
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+
+    const output = stdout.write.mock.calls.map(c => c[0]).join('')
+    const parsed = JSON.parse(output)
+
+    expect(parsed.label).toBe('github-main')
+    expect(parsed.service).toBe('github.com')
+    expect(output).toContain('\n')
+  })
+
+  it('fails when show-profile target does not exist', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ showProfileLabel: 'missing' }),
+      {
+        loadProfileByLabel: async () => {
+          throw new Error("Profile 'missing' does not exist")
+        },
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
+  })
 })

--- a/test/fixtures/cli.js
+++ b/test/fixtures/cli.js
@@ -12,6 +12,7 @@ export function makeCliArgs(overrides = {}) {
     save: false,
     create: null,
     deleteLabel: null,
+    showProfileLabel: null,
     ...overrides
   }
 }

--- a/test/fixtures/profiles.js
+++ b/test/fixtures/profiles.js
@@ -9,6 +9,7 @@ export const DEFAULT_PROFILE = {
   length: 20,
   require: ['lower', 'upper', 'digit', 'symbol'],
   symbolSet: '!@#',
+  notes: '',
   createdAt: '2026-04-12T00:00:00.000Z',
   updatedAt: '2026-04-12T00:00:00.000Z'
 }

--- a/test/profile-serialization.test.js
+++ b/test/profile-serialization.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { serializeProfilePretty } from '../src/profile-serialization.js'
+import { makeProfile } from './fixtures/profiles.js'
+
+describe('serializeProfilePretty', () => {
+  it('returns valid pretty-printed JSON', () => {
+    const profile = makeProfile({ label: 'github-main' })
+    const text = serializeProfilePretty(profile)
+    const parsed = JSON.parse(text)
+
+    expect(parsed.label).toBe('github-main')
+    expect(text).toContain('\n')
+    expect(text).toContain('  ')
+  })
+
+  it('serializes all present fields in stable order', () => {
+    const profile = makeProfile({
+      account: 'peter@example.com',
+      notes: 'Main account'
+    })
+
+    const text = serializeProfilePretty(profile)
+    const parsed = JSON.parse(text)
+
+    expect(parsed).toEqual(profile)
+
+    expect(Object.keys(parsed)).toEqual([
+      'version',
+      'label',
+      'service',
+      'account',
+      'counter',
+      'length',
+      'require',
+      'symbolSet',
+      'notes',
+      'createdAt',
+      'updatedAt'
+    ])
+  })
+
+  it('omits optional fields that are not present', () => {
+    const profile = makeProfile()
+    delete profile.account
+    delete profile.notes
+
+    const text = serializeProfilePretty(profile)
+    const parsed = JSON.parse(text)
+
+    expect(parsed.account).toBeUndefined()
+    expect(parsed.notes).toBeUndefined()
+
+    expect(Object.keys(parsed)).toEqual([
+      'version',
+      'label',
+      'service',
+      'counter',
+      'length',
+      'require',
+      'symbolSet',
+      'createdAt',
+      'updatedAt'
+    ])
+  })
+
+  it('does not mutate the original profile', () => {
+    const profile = makeProfile({ label: 'github-main' })
+    const before = JSON.stringify(profile)
+
+    serializeProfilePretty(profile)
+
+    expect(JSON.stringify(profile)).toBe(before)
+  })
+})


### PR DESCRIPTION
## DPG-004: Show profile (`--show-profile`)

Adds `dpg --show-profile <label>` to display a profile as pretty-printed JSON.

- outputs valid, human-readable JSON
- preserves stable field ordering
- includes all present fields
- returns clear errors for missing / unknown labels

Also strengthens serialization tests so output structure is verified properly, not just smoke-tested.