### PR TITLE
DPG-008: Refactor: centralize core typedefs in models module

### DIFF
--- a/src/cli-args.js
+++ b/src/cli-args.js
@@ -1,16 +1,4 @@
-/**
- * @typedef {{
- *   profileLabel: string | null,
- *   show: boolean,
- *   help: boolean,
- *   list: boolean,
- *   bump: string | null,
- *   save: boolean,
- *   create: string | null,
- *   deleteLabel: string | null,
- *   showProfileLabel: string | null
- * }} CliArgs
- */
+/** @typedef {import('./models.js').CliArgs} CliArgs */
 
 /**
  * @param {string[]} argv

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -6,23 +6,11 @@ import { copyToClipboard } from './clipboard.js'
 import { usageText } from './cli-args.js'
 import { promptForConfirmation } from './confirm.js'
 import { serializeProfilePretty } from './profile-serialization.js'
+/** @typedef {import('./models.js').CliDeps} CliDeps */
+/** @typedef {import('./models.js').CliArgs} CliArgs */
 
 /**
- * @typedef {{
- *   loadProfileByLabel?: (label: string) => Promise<any>,
- *   loadAllProfiles?: () => Promise<any[]>,
- *   saveProfiles?: (profiles: any[]) => Promise<void>,
- *   promptForMasterPassword?: () => Promise<string>,
- *   generatePassword?: (master: string, profile: any) => Promise<string>,
- *   copyToClipboard?: (text: string) => Promise<void>,
- *   promptForConfirmation?: (prompt: string) => Promise<string>,
- *   stdout?: { write: (s: string) => void },
- *   stderr?: { write: (s: string) => void }
- * }} CliDeps
- */
-
-/**
- * @param {import('./cli-args.js').CliArgs} args
+ * @param {CliArgs} args
  * @param {CliDeps=} deps
  * @returns {Promise<number>}
  */

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -1,13 +1,17 @@
 import { spawn as realSpawn } from 'node:child_process'
 import { accessSync, constants } from 'node:fs'
 import path from 'node:path'
+/** @typedef {import('./models.js').ClipboardChildProcess} ClipboardChildProcess */
+/** @typedef {import('./models.js').ClipboardSpawn} ClipboardSpawn */
+/** @typedef {import('./models.js').ClipboardCommand} ClipboardCommand */
+/** @typedef {import('./models.js').ClipboardEnvironment} ClipboardEnvironment */
+/** @typedef {import('./models.js').ClipboardOptions} ClipboardOptions */
 
 /**
  * @param {string} name
  * @returns {boolean}
  */
 function commandExists(name) {
-  /** @type {string} */
   const pathValue = process.env.PATH ?? ''
   const extensions = process.platform === 'win32'
     ? ['.exe', '.cmd', '.bat', '']
@@ -28,21 +32,8 @@ function commandExists(name) {
 }
 
 /**
- * @typedef {{
- *   stdin: {
- *     end: (text: string) => void
- *   },
- *   on: (event: 'error' | 'close', handler: (value: any) => void) => void
- * }} ClipboardChildProcess
- */
-
-/**
- * @typedef {(command: string, args: string[], options: object) => ClipboardChildProcess} ClipboardSpawn
- */
-
-/**
- * @param {{ platform?: string, hasCommand?: (name: string) => boolean }=} options
- * @returns {{ command: string, args: string[] }}
+ * @param {ClipboardEnvironment=} options
+ * @returns {ClipboardCommand}
  */
 export function getClipboardCommand(options = {}) {
   const platform = options.platform ?? process.platform
@@ -74,16 +65,11 @@ export function getClipboardCommand(options = {}) {
 
 /**
  * @param {string} text
- * @param {{
- *   platform?: string,
- *   hasCommand?: (name: string) => boolean,
- *   spawn?: ClipboardSpawn
- * }=} options
+ * @param {ClipboardOptions=} options
  * @returns {Promise<void>}
  */
 export function copyToClipboard(text, options = {}) {
   const { command, args } = getClipboardCommand(options)
-  /** @type {ClipboardSpawn} */
   const spawn = options.spawn ?? realSpawn
 
   return new Promise((resolve, reject) => {

--- a/src/models.js
+++ b/src/models.js
@@ -1,0 +1,96 @@
+/**
+ * @typedef {'lower' | 'upper' | 'digit' | 'symbol'} RequireClass
+ */
+
+/**
+ * @typedef {'label' | 'service' | 'createdAt' | 'updatedAt' | 'counter'} ProfileSortField
+ */
+
+/**
+ * @typedef {{
+ *   version: string,
+ *   label: string,
+ *   service: string,
+ *   account?: string,
+ *   counter: number,
+ *   length: number,
+ *   require: RequireClass[],
+ *   symbolSet?: string,
+ *   notes?: string,
+ *   createdAt?: string,
+ *   updatedAt?: string
+ * }} Profile
+ */
+
+/**
+ * @typedef {{
+ *   length: number,
+ *   require: string[],
+ *   symbolSet?: string
+ * }} PasswordPolicyInput
+ */
+
+/**
+ * @typedef {{
+ *   timeout?: number,
+ *   sortBy?: ProfileSortField
+ * }} Config
+ */
+
+/**
+ * @typedef {{
+ *   profileLabel: string | null,
+ *   show: boolean,
+ *   help: boolean,
+ *   list: boolean,
+ *   bump: string | null,
+ *   save: boolean,
+ *   create: string | null,
+ *   deleteLabel: string | null,
+ *   showProfileLabel: string | null
+ * }} CliArgs
+ */
+
+/**
+ * @typedef {{
+ *   loadProfileByLabel?: (label: string) => Promise<Profile>,
+ *   loadAllProfiles?: () => Promise<Profile[]>,
+ *   saveProfiles?: (profiles: Profile[]) => Promise<void>,
+ *   promptForMasterPassword?: () => Promise<string>,
+ *   promptForConfirmation?: (prompt: string) => Promise<string>,
+ *   generatePassword?: (master: string, profile: Profile) => Promise<string>,
+ *   copyToClipboard?: (text: string) => Promise<void>,
+ *   stdout?: { write: (s: string) => void },
+ *   stderr?: { write: (s: string) => void }
+ * }} CliDeps
+ */
+
+/**
+ * @typedef {{
+ *   stdin: { end: (text: string) => void },
+ *   on: (event: 'error' | 'close', handler: (value: any) => void) => void
+ * }} ClipboardChildProcess
+ */
+
+/**
+ * @typedef {(command: string, args: string[], options: object) => ClipboardChildProcess} ClipboardSpawn
+ */
+
+/**
+ * @typedef {{ command: string, args: string[] }} ClipboardCommand
+ */
+
+/**
+ * @typedef {{
+ *   platform?: string,
+ *   hasCommand?: (name: string) => boolean
+ * }} ClipboardEnvironment
+ */
+
+/**
+ * @typedef {ClipboardEnvironment & {
+ *   spawn?: ClipboardSpawn
+ * }} ClipboardOptions
+ */
+
+export {}

--- a/src/password.js
+++ b/src/password.js
@@ -1,6 +1,7 @@
 import { ByteStream } from './stream.js'
 import { uniformIndex } from './uniform.js'
 import { deterministicShuffle } from './shuffle.js'
+/** @typedef {import('./models.js').PasswordPolicyInput} PasswordPolicyInput */
 
 const LOWER = 'abcdefghijklmnopqrstuvwxyz'
 const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -43,6 +44,11 @@ function pickChar(stream, alphabet) {
   return alphabet[uniformIndex(stream, alphabet.length)]
 }
 
+/**
+ * @param {Uint8Array} siteKey
+ * @param {PasswordPolicyInput} profile
+ * @returns {string}
+ */
 export function generatePasswordFromSiteKey(siteKey, profile) {
   const require = canonicalRequire(profile.require ?? [])
   const length = profile.length

--- a/src/profile-factory.js
+++ b/src/profile-factory.js
@@ -1,5 +1,5 @@
 import { validateProfileLabel } from './profile-validation.js'
-/** @typedef {import('../src/models.js').RequireClass} RequireClass */
+/** @typedef {import('./models.js').RequireClass} RequireClass */
 
 /** @type RequireClass[] */
 export const DEFAULT_REQUIRE = ['lower', 'upper', 'digit', 'symbol']

--- a/src/profile-factory.js
+++ b/src/profile-factory.js
@@ -1,7 +1,10 @@
 import { validateProfileLabel } from './profile-validation.js'
+/** @typedef {import('../src/models.js').RequireClass} RequireClass */
 
+/** @type RequireClass[] */
 export const DEFAULT_REQUIRE = ['lower', 'upper', 'digit', 'symbol']
 export const DEFAULT_SYMBOL_SET = '!@#'
+
 /**
  * @param {string} label
  * @param {string=} now

--- a/src/profile-serialization.js
+++ b/src/profile-serialization.js
@@ -1,3 +1,4 @@
+/** @typedef {import('./models.js').Profile} Profile */
 const PROFILE_FIELD_ORDER = [
   'version',
   'label',
@@ -13,15 +14,11 @@ const PROFILE_FIELD_ORDER = [
 ]
 
 /**
- * @typedef {import('./profiles-file.js').Profile} Profile
- */
-
-/**
  * @param {Profile} profile
  * @returns {Profile}
  */
 export function normalizeProfileFieldOrder(profile) {
-  /** @type {Record<string, any>} */
+  /** @type Partial<Profile> */
   const ordered = {}
 
   for (const key of PROFILE_FIELD_ORDER) {
@@ -36,7 +33,8 @@ export function normalizeProfileFieldOrder(profile) {
     }
   }
 
-  return /** @type {Profile} */ (ordered)
+  // At this point, all required fields should be present, so cast is safe.
+  return /** @type Profile */ (ordered)
 }
 
 /**

--- a/src/profiles-file.js
+++ b/src/profiles-file.js
@@ -1,22 +1,7 @@
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'node:fs/promises'
-
-/**
- * @typedef {{
- *   version: string,
- *   label: string,
- *   service: string,
- *   account?: string,
- *   counter: number,
- *   length: number,
- *   require: string[],
- *   symbolSet?: string,
- *   notes?: string,
- *   createdAt?: string,
- *   updatedAt?: string
- * }} Profile
- */
+/** @typedef {import('./models.js').Profile} Profile */
 
 /**
  * @param {{ platform?: string, homeDir?: string }=} options

--- a/src/stream.js
+++ b/src/stream.js
@@ -7,7 +7,7 @@ export class ByteStream {
   constructor(siteKey) {
     this.key = Buffer.from(siteKey)
     this.blockIndex = 0
-    /** @type {number[]} */
+    /** @type number[] */
     this.buffer = []
   }
 

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -7,6 +7,7 @@ import fs from 'node:fs/promises'
 import path from "node:path";
 import {tmpdir} from "node:os";
 import {loadAllProfiles, saveProfiles} from "../src/profiles-file.js";
+/** @typedef {import('../src/models.js').Profile} Profile */
 
 describe('runCli', () => {
   it('loads profile, prompts for password, generates, copies, and prints success', async () => {
@@ -58,7 +59,7 @@ describe('runCli', () => {
 
   it('creates a new profile', async () => {
 
-    /** @type {import('../src/profiles-file.js').Profile[] | null} */
+    /** @type Profile[] */
     let savedProfiles = null
     const stdout = { write: vi.fn() }
 
@@ -76,8 +77,6 @@ describe('runCli', () => {
 
     if (!savedProfiles) throw new Error('not saved')
     expect(savedProfiles).toHaveLength(1)
-
-    /** @type {import('../src/profiles-file.js').Profile} */
     const savedProfile = savedProfiles[0]
     expect(savedProfile.label).toBe('github-main')
     expect(savedProfile.service).toBe('github-main')
@@ -191,7 +190,7 @@ describe('runCli', () => {
       updatedAt: '2020-01-01T00:00:00.000Z'
     })
 
-    /** @type {import('../src/profiles-file.js').Profile[] | null} */
+    /** @type Profile[] */
     let savedProfiles = null
 
     await runCli(
@@ -209,10 +208,7 @@ describe('runCli', () => {
     )
 
     if (!savedProfiles) throw new Error('not saved')
-
-    /** @type {import('../src/profiles-file.js').Profile} */
     const savedProfile = savedProfiles[0]
-
     expect(savedProfile.updatedAt).not.toBe(profile.updatedAt)
   })
 
@@ -300,7 +296,7 @@ describe('runCli', () => {
       makeProfile({ label: 'gitlab-main', service: 'gitlab.com' })
     ]
 
-    /** @type {import('../src/profiles-file.js').Profile[] | null} */
+    /** @type Profile[] */
     let savedProfiles = null
 
     const stdout = { write: vi.fn() }

--- a/test/clipboard.test.js
+++ b/test/clipboard.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { getClipboardCommand, copyToClipboard } from '../src/clipboard.js'
+/** @typedef {import('../src/models.js').ClipboardChildProcess} ClipboardChildProcess */
 
 describe('getClipboardCommand', () => {
   it('uses pbcopy on macOS', () => {
@@ -48,12 +49,9 @@ describe('getClipboardCommand', () => {
 describe('copyToClipboard', () => {
   it('writes to the selected clipboard process stdin', async () => {
     const end = vi.fn()
-    const spawn = vi.fn(() => ({
+    const spawn = vi.fn(() => /** @type {ClipboardChildProcess} */ ({
       stdin: { end },
-      on: (
-        /** @type {'error' | 'close'} */ event,
-        /** @type {(value: any) => void} */ handler
-      ) => {
+      on: (event, handler) => {
         if (event === 'close') handler(0)
       }
     }))

--- a/test/fixtures/cli.js
+++ b/test/fixtures/cli.js
@@ -1,6 +1,8 @@
+/** @typedef {import('../../src/cli-args.js').CliArgs} CliArgs */
+
 /**
- * @param {Partial<import('../../src/cli-args.js').CliArgs>=} overrides
- * @returns {import('../../src/cli-args.js').CliArgs}
+ * @param {Partial<CliArgs>=} overrides
+ * @returns {CliArgs}
  */
 export function makeCliArgs(overrides = {}) {
   return {

--- a/test/fixtures/cli.js
+++ b/test/fixtures/cli.js
@@ -1,4 +1,4 @@
-/** @typedef {import('../../src/cli-args.js').CliArgs} CliArgs */
+/** @typedef {import('../../src/models.js').CliArgs} CliArgs */
 
 /**
  * @param {Partial<CliArgs>=} overrides

--- a/test/fixtures/profiles.js
+++ b/test/fixtures/profiles.js
@@ -1,5 +1,6 @@
-/** @typedef {import('../../src/profiles-file.js').Profile} Profile */
-/** @type {Profile} */
+/** @typedef {import('../../src/models.js').Profile} Profile */
+
+/** @type Profile */
 export const DEFAULT_PROFILE = {
   version: 'dpg:v2',
   label: 'github-main',
@@ -15,7 +16,7 @@ export const DEFAULT_PROFILE = {
 }
 
 /**
- * @param {Partial<import('../../src/profiles-file.js').Profile>=} overrides
+ * @param {Partial<Profile>=} overrides
  * @returns {Profile}
  */
 export function makeProfile(overrides = {}) {


### PR DESCRIPTION
- introduce src/models.js as single source of truth for core types
- unify Profile, Config, CliArgs, CliDeps and related typedefs
- remove scattered and duplicate inline typedefs
- update imports across src and tests

no behavior changes, existing tests pass unchanged