### PR TITLE
DPG-005: CLI validation and error handling

### DIFF
--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -32,12 +32,9 @@ export async function runCli(args, deps = {}) {
     return 0
   }
 
-  if (!args.profileLabel && !args.bump && !args.list && !args.create && !args.deleteLabel && !args.showProfileLabel) {
-    stderr.write('No command specified. Use -p <label>, -b <label>, --list, -n <label>, -D <label>, or --show-profile <label>. See -h for help.\n')
-    return 1
-  }
-
   try {
+    checkForConflicts(args)
+
     if (args.list) {
       const profiles = await loadAll()
 
@@ -168,3 +165,65 @@ export async function runCli(args, deps = {}) {
     return 1
   }
 }
+
+/**
+ * @param {CliArgs} args
+ * @returns void
+ */
+function checkForConflicts(args) {
+  const primary = []
+  const usedTokens = []
+
+  if (args.profileLabel) {
+    primary.push('profile')
+    usedTokens.push('-p')
+  }
+
+  if (args.list) {
+    primary.push('list')
+    usedTokens.push('-l')
+  }
+
+  if (args.bump) {
+    primary.push('bump')
+    usedTokens.push('-b')
+  }
+
+  if (args.create) {
+    primary.push('create')
+    usedTokens.push('-n')
+  }
+
+  if (args.deleteLabel) {
+    primary.push('delete')
+    usedTokens.push('-D')
+  }
+
+  if (args.showProfileLabel) {
+    primary.push('show-profile')
+    usedTokens.push('show-profile')
+  }
+
+  if (args.save && !args.bump) {
+    throw new Error('--save is only valid with --bump')
+  }
+
+  if (args.show && !(args.profileLabel || args.bump)) {
+    throw new Error('--show is only valid with --profile or --bump')
+  }
+
+  if (args.show && args.list) {
+    throw new Error('--show cannot be used with --list')
+  }
+
+  if (primary.length === 0) {
+    throw new Error('No command specified. See -h for help.')
+  }
+
+  if (primary.length > 1) {
+    throw new Error(
+      `Conflicting commands: ${usedTokens.join(', ')} — specify only one primary action`
+    )
+  }
+}
+

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -175,33 +175,37 @@ function checkForConflicts(args) {
   const usedTokens = []
 
   if (args.profileLabel) {
-    primary.push('profile')
+    primary.push('--profile')
     usedTokens.push('-p')
   }
 
   if (args.list) {
-    primary.push('list')
+    primary.push('--list')
     usedTokens.push('-l')
   }
 
   if (args.bump) {
-    primary.push('bump')
+    primary.push('--bump')
     usedTokens.push('-b')
   }
 
   if (args.create) {
-    primary.push('create')
+    primary.push('--create')
     usedTokens.push('-n')
   }
 
   if (args.deleteLabel) {
-    primary.push('delete')
+    primary.push('--delete')
     usedTokens.push('-D')
   }
 
   if (args.showProfileLabel) {
-    primary.push('show-profile')
+    primary.push('--show-profile')
     usedTokens.push('show-profile')
+  }
+
+  if (primary.length === 0) {
+    throw new Error('No command specified. See -h for help.')
   }
 
   if (args.save && !args.bump) {
@@ -214,10 +218,6 @@ function checkForConflicts(args) {
 
   if (args.show && args.list) {
     throw new Error('--show cannot be used with --list')
-  }
-
-  if (primary.length === 0) {
-    throw new Error('No command specified. See -h for help.')
   }
 
   if (primary.length > 1) {

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -175,33 +175,33 @@ function checkForConflicts(args) {
   const usedTokens = []
 
   if (args.profileLabel) {
-    primary.push('--profile')
+    primary.push('profile')
     usedTokens.push('-p')
   }
 
   if (args.list) {
-    primary.push('--list')
+    primary.push('list')
     usedTokens.push('-l')
   }
 
   if (args.bump) {
-    primary.push('--bump')
+    primary.push('bump')
     usedTokens.push('-b')
   }
 
   if (args.create) {
-    primary.push('--create')
+    primary.push('create')
     usedTokens.push('-n')
   }
 
   if (args.deleteLabel) {
-    primary.push('--delete')
+    primary.push('delete')
     usedTokens.push('-D')
   }
 
   if (args.showProfileLabel) {
-    primary.push('--show-profile')
-    usedTokens.push('show-profile')
+    primary.push('show-profile')
+    usedTokens.push('--show-profile')
   }
 
   if (primary.length === 0) {

--- a/test/cli-args.test.js
+++ b/test/cli-args.test.js
@@ -30,10 +30,6 @@ describe('parseArgs', () => {
     })
   })
 
-  it('throws if profile label is missing', () => {
-    expect(() => parseArgs(['-p'])).toThrow(/profile label/i)
-  })
-
   it('parses -n <label>', () => {
     expect(parseArgs(['-n', 'github-main'])).toEqual({
       profileLabel: null,
@@ -62,10 +58,6 @@ describe('parseArgs', () => {
     })
   })
 
-  it('throws if label is missing after -n/--new', () => {
-    expect(() => parseArgs(['-n'])).toThrow(/label/i)
-  })
-
   it('parses -D <label>', () => {
     expect(parseArgs(['-D', 'github-main'])).toEqual({
       profileLabel: null,
@@ -92,10 +84,6 @@ describe('parseArgs', () => {
       deleteLabel: 'github-main',
       showProfileLabel: null
     })
-  })
-
-  it('throws if label is missing after -D/--delete', () => {
-    expect(() => parseArgs(['-D'])).toThrow(/label/i)
   })
 
   it('parses -b <label>', () => {
@@ -140,10 +128,6 @@ describe('parseArgs', () => {
     })
   })
 
-  it('throws if label is missing after --show-profile', () => {
-    expect(() => parseArgs(['--show-profile'])).toThrow(/label/i)
-  })
-
   it('parses --help', () => {
     expect(parseArgs(['--help'])).toEqual({
       profileLabel: null,
@@ -158,7 +142,35 @@ describe('parseArgs', () => {
     })
   })
 
-  it('throws on unknown argument', () => {
-    expect(() => parseArgs(['--wat'])).toThrow(/unknown argument/i)
+  it('throws if profile label is missing after -p/--profile', () => {
+    expect(() => parseArgs(['-p'])).toThrow(/missing profile label/i)
+    expect(() => parseArgs(['--profile'])).toThrow(/missing profile label/i)
+  })
+
+  it('throws if label is missing after -b/--bump', () => {
+    expect(() => parseArgs(['-b'])).toThrow(/missing/i)
+    expect(() => parseArgs(['--bump'])).toThrow(/missing/i)
+  })
+
+  it('throws if label is missing after -n/--new', () => {
+    expect(() => parseArgs(['-n'])).toThrow(/missing profile label/i)
+    expect(() => parseArgs(['--new'])).toThrow(/missing profile label/i)
+  })
+
+  it('throws if label is missing after -D/--delete', () => {
+    expect(() => parseArgs(['-D'])).toThrow(/missing profile label/i)
+    expect(() => parseArgs(['--delete'])).toThrow(/missing profile label/i)
+  })
+
+  it('throws if label is missing after --show-profile', () => {
+    expect(() => parseArgs(['--show-profile'])).toThrow(/missing profile label/i)
+  })
+
+  it('throws on unknown long flag', () => {
+    expect(() => parseArgs(['--shwo'])).toThrow(/unknown/i)
+  })
+
+  it('throws on unknown short flag', () => {
+    expect(() => parseArgs(['-z'])).toThrow(/unknown/i)
   })
 })

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -212,7 +212,7 @@ describe('runCli', () => {
     expect(savedProfile.updatedAt).not.toBe(profile.updatedAt)
   })
 
-  it('fails if profile does not exist', async () => {
+  it('fails to bump if profile does not exist', async () => {
     const stderr = { write: vi.fn() }
 
     const exitCode = await runCli(
@@ -436,21 +436,85 @@ describe('runCli', () => {
     expect(output).toContain('\n')
   })
 
-  it('fails when show-profile target does not exist', async () => {
+  it('fails when --show-profile target does not exist', async () => {
     const stderr = { write: vi.fn() }
 
     const exitCode = await runCli(
-      makeCliArgs({ showProfileLabel: 'missing' }),
+      makeCliArgs({ showProfileLabel: 'nope' }),
       {
         loadProfileByLabel: async () => {
-          throw new Error("Profile 'missing' does not exist")
+          throw new Error("Profile 'nope' does not exist")
         },
         stdout: { write: vi.fn() },
         stderr
       }
     )
 
-    expect(exitCode).toBe(1)
     expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
+    expect(exitCode).toBe(1)
+  })
+
+  it('fails if multiple primary commands are used', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({
+        create: 'a',
+        deleteLabel: 'b',
+        bump: 'c'
+      }),
+      { stdout: { write: vi.fn() }, stderr }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(
+      expect.stringMatching(/conflicting commands/i)
+    )
+  })
+
+  it('fails if --show is used without a valid command', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ show: true }),
+      { stdout: { write: vi.fn() }, stderr }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/show/i))
+  })
+
+  it('fails if --save is used without --bump', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ save: true }),
+      { stdout: { write: vi.fn() }, stderr }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/save/i))
+  })
+
+  it('fails if --save is used with --profile', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ profileLabel: 'x', save: true }),
+      { stdout: { write: vi.fn() }, stderr }
+    )
+
+    expect(exitCode).toBe(1)
+  })
+
+  it('fails if --show is used with --list', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ list: true, show: true }),
+      { stdout: { write: vi.fn() }, stderr }
+    )
+
+    expect(exitCode).toBe(1)
   })
 })

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -476,7 +476,7 @@ describe('runCli', () => {
     const stderr = { write: vi.fn() }
 
     const exitCode = await runCli(
-      makeCliArgs({ show: true }),
+      makeCliArgs({ deleteLabel: 'missing', show: true }),
       { stdout: { write: vi.fn() }, stderr }
     )
 
@@ -488,7 +488,7 @@ describe('runCli', () => {
     const stderr = { write: vi.fn() }
 
     const exitCode = await runCli(
-      makeCliArgs({ save: true }),
+      makeCliArgs({ profileLabel: 'missing', save: true }),
       { stdout: { write: vi.fn() }, stderr }
     )
 


### PR DESCRIPTION
## CLI validation and error handling

Adds strict validation for CLI arguments:

- rejects missing labels and unknown flags
- enforces a single primary command per invocation
- validates supported flag combinations (e.g. `--save`, `--show`)
- returns clear and consistent error messages

Includes additional tests covering invalid and edge-case invocations.

No changes to valid command behavior.