### PR TITLE
DPG-007: Add basic config support (--config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,21 @@ Useful for:
 - verifying stored fields
 - piping into tools such as `jq`
 
+### Show config
+
+    dpg --config
+
+Prints the current config as pretty-printed JSON.
+
+### Update config
+
+    dpg --config timeout=900
+    dpg --config sortBy=label
+
+Supported keys:
+- `timeout` — non-negative integer seconds
+- `sortBy` — currently only `label`
+
 ### Help
 
     dpg --help

--- a/src/cli-args.js
+++ b/src/cli-args.js
@@ -52,9 +52,14 @@ export function parseArgs(argv) {
       showProfileLabel = next
     } else if (arg === '-c' || arg === '--config') {
       configPresent = true
-      const next = argv[++i]
+      const next = argv[i + 1]
       if (next && !next.startsWith('-')) {
+        if (!next.includes('=')) {
+          throw new Error('Config update must use key=value syntax')
+        }
+
         configArg = next
+        i++
       }
     } else if (arg === '--list') {
       list = true

--- a/src/cli-args.js
+++ b/src/cli-args.js
@@ -14,6 +14,8 @@ export function parseArgs(argv) {
   let create = null
   let deleteLabel = null
   let showProfileLabel = null
+  let configPresent = false
+  let configArg = null
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
@@ -48,6 +50,12 @@ export function parseArgs(argv) {
         throw new Error('Missing profile label after --show-profile')
       }
       showProfileLabel = next
+    } else if (arg === '-c' || arg === '--config') {
+      configPresent = true
+      const next = argv[++i]
+      if (next && !next.startsWith('-')) {
+        configArg = next
+      }
     } else if (arg === '--list') {
       list = true
     } else if (arg === '--save') {
@@ -61,7 +69,7 @@ export function parseArgs(argv) {
     }
   }
 
-  return { profileLabel, show, help, list, bump, save, create, deleteLabel, showProfileLabel }
+  return { profileLabel, show, help, list, bump, save, create, deleteLabel, showProfileLabel, configPresent, configArg }
 }
 
 export function usageText() {
@@ -80,17 +88,22 @@ export function usageText() {
     '  dpg -D <label>',
     '  dpg --delete <label>',
     '  dpg --show-profile <label>',
+    '  dpg -c',
+    '  dpg --config',
+    '  dpg -c <key=value>',
+    '  dpg --config <key=value>',
     '  dpg --help',
     '',
     'Options:',
-    '  -p, --profile <label>       Generate password from existing profile',
-    '  -b, --bump <label>          Generate password using counter + 1',
-    '      --save                  Persist changes made by --bump',
-    '      --show                  Print generated password to stdout',
-    '      --list                  List available profiles',
-    '  -n, --new <label>           Create a new profile with default values',
-    '  -D, --delete <label>        Delete an existing profile (confirmation required)',
-    '      --show-profile <label>  Pretty-print a profile as JSON',
-    '  -h, --help                  Show this help text'
+    '  -p, --profile <label>        Generate password from existing profile',
+    '  -b, --bump <label>           Generate password using counter + 1',
+    '      --save                   Persist changes made by --bump',
+    '      --show                   Print generated password to stdout',
+    '      --list                   List available profiles',
+    '  -n, --new <label>            Create a new profile with default values',
+    '  -D, --delete <label>         Delete an existing profile (confirmation required)',
+    '      --show-profile <label>   Pretty-print a profile as JSON',
+    '      -c, --config [key=value] Show config or update a single config value',
+    '  -h, --help                   Show this help text'
   ].join('\n')
 }

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -7,6 +7,7 @@ import { usageText } from './cli-args.js'
 import { promptForConfirmation } from './confirm.js'
 import { serializeProfilePretty } from './profile-serialization.js'
 import { formatProfileList } from './list-formatting.js'
+import {loadConfig, saveConfig, parseConfigAssignment, applyConfigUpdate} from "./config-file.js";
 /** @typedef {import('./models.js').CliDeps} CliDeps */
 /** @typedef {import('./models.js').CliArgs} CliArgs */
 
@@ -24,6 +25,8 @@ export async function runCli(args, deps = {}) {
     generatePassword: generate = generatePassword,
     copyToClipboard: copy = copyToClipboard,
     promptForConfirmation: confirm = promptForConfirmation,
+    loadConfig: loadCfg = loadConfig,
+    saveConfig: saveCfg = saveConfig,
     stdout = process.stdout,
     stderr = process.stderr
   } = deps
@@ -38,7 +41,8 @@ export async function runCli(args, deps = {}) {
 
     if (args.list) {
       const profiles = await loadAll()
-      stdout.write(formatProfileList(profiles) + '\n')
+      const config = await loadCfg()
+      stdout.write(formatProfileList(profiles, config.sortBy) + '\n')
       return 0
     }
 
@@ -132,6 +136,22 @@ export async function runCli(args, deps = {}) {
       return 0
     }
 
+    if (args.configPresent) {
+      const config = await loadCfg()
+
+      if (args.configArg === null) {
+        stdout.write(JSON.stringify(config, null, 2) + '\n')
+        return 0
+      }
+
+      const { key, value } = parseConfigAssignment(args.configArg)
+      const updated = applyConfigUpdate(config, key, value)
+
+      await saveCfg(updated)
+      stdout.write(`Updated config: ${key}=${value}\n`)
+      return 0
+    }
+
     const profile = await load(args.profileLabel)
     const masterPassword = await prompt()
     const password = await generate(masterPassword, profile)
@@ -192,6 +212,11 @@ function checkForConflicts(args) {
     usedTokens.push('--show-profile')
   }
 
+  if (args.configPresent) {
+    primary.push('config')
+    usedTokens.push('-c')
+  }
+
   if (primary.length === 0) {
     throw new Error('No command specified. See -h for help.')
   }
@@ -214,4 +239,3 @@ function checkForConflicts(args) {
     )
   }
 }
-

--- a/src/config-file.js
+++ b/src/config-file.js
@@ -1,0 +1,119 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+/** @typedef {import('./models.js').Config} Config */
+
+function resolveConfigPath(options = {}) {
+  return options.configPath ?? path.join(os.homedir(), '.dpg-v2', 'config.json')
+}
+
+/**
+ * @returns {Config}
+ */
+export function defaultConfig() {
+  return {
+    timeout: 0,
+    sortBy: 'label'
+  }
+}
+
+/**
+ * @param {string} text
+ * @returns {{ key: string, value: string }}
+ */
+export function parseConfigAssignment(text) {
+  const trimmed = text.trim()
+  const equals = trimmed.indexOf('=')
+
+  if (equals === -1) {
+    throw new Error('Config update must use key=value syntax')
+  }
+
+  const key = trimmed.slice(0, equals).trim()
+  const value = trimmed.slice(equals + 1).trim()
+
+  if (!key) {
+    throw new Error('Missing config key')
+  }
+
+  if (!value) {
+    throw new Error(`Missing value for config key '${key}'`)
+  }
+
+  return { key, value }
+}
+
+/**
+ * @param {Config} config
+ * @param {string} key
+ * @param {string} value
+ * @returns {Config}
+ */
+export function applyConfigUpdate(config, key, value) {
+  if (key === 'timeout') {
+    if (!/^\d+$/.test(value)) {
+      throw new Error(`Invalid timeout: '${value}'. Timeout must be a non-negative integer.`)
+    }
+
+    return {
+      ...config,
+      timeout: Number(value)
+    }
+  }
+
+  if (key === 'sortBy') {
+    if (value !== 'label') {
+      throw new Error(`Unsupported sortBy value: '${value}'`)
+    }
+
+    return {
+      ...config,
+      sortBy: 'label'
+    }
+  }
+
+  throw new Error(`Unknown config key: '${key}'`)
+}
+
+/**
+ * @param {{ configPath?: string }=} options
+ * @returns {Promise<Config>}
+ */
+export async function loadConfig(options = {}) {
+  const configPath = resolveConfigPath(options)
+
+  let text
+  try {
+    text = await fs.readFile(configPath, 'utf8')
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return defaultConfig()
+    }
+    throw err
+  }
+
+  const parsed = JSON.parse(text)
+
+  return {
+    timeout: parsed.timeout ?? 0,
+    sortBy: parsed.sortBy ?? 'label'
+  }
+}
+
+/**
+ * @param {Config} config
+ * @param {{ configPath?: string }=} options
+ * @returns {Promise<void>}
+ */
+export async function saveConfig(config, options = {}) {
+  const configPath = resolveConfigPath(options)
+  const dir = path.dirname(configPath)
+  const tmpPath = configPath + '.tmp'
+
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(tmpPath, JSON.stringify({
+    timeout: config.timeout,
+    sortBy: config.sortBy
+  }, null, 2), 'utf8')
+  await fs.rename(tmpPath, configPath)
+}

--- a/src/context.js
+++ b/src/context.js
@@ -1,12 +1,27 @@
+/** @typedef {import('./models.js').Profile} Profile */
+/** @typedef {import('./models.js').RequireClass} RequireClass */
+/**
+ * @param {Profile} profile
+ * @returns {Uint8Array<ArrayBuffer>}
+ */
 export function encodeContext(profile) {
   const encoder = new TextEncoder()
 
+  /**
+   * @param {string} str
+   * @returns {string}
+   */
   function field(str) {
     const bytes = encoder.encode(str)
     return `${bytes.length}:${str}\0`
   }
 
+  /**
+   * @param {RequireClass[]} req
+   * @returns {string}
+   */
   function normalizeRequire(req) {
+    /** @type RequireClass[] */
     const order = ['lower', 'upper', 'digit', 'symbol']
     return order.filter(x => req.includes(x)).join(',')
   }

--- a/src/list-formatting.js
+++ b/src/list-formatting.js
@@ -1,15 +1,20 @@
-/**
- * @typedef {import('./models.js').Profile} Profile
- */
+/** @typedef {import('./models.js').Profile} Profile */
+/** @typedef {import('./models.js').ProfileSortField} ProfileSortField */
 
 /**
  * @param {Profile[]} profiles
+ * @param {ProfileSortField=} sortBy
  * @returns {string}
  */
-export function formatProfileList(profiles) {
-  const sorted = [...profiles].sort((a, b) =>
-    a.label.localeCompare(b.label)
-  )
+export function formatProfileList(profiles, sortBy = 'label') {
+  const sorted = [...profiles]
+
+  if (sortBy === 'label') {
+    sorted.sort((a, b) => a.label.localeCompare(b.label))
+  } else {
+    // Defensive fallback for future values not yet implemented in list formatting.
+    sorted.sort((a, b) => a.label.localeCompare(b.label))
+  }
 
   const labelWidth = Math.max(
     'label'.length,
@@ -17,14 +22,16 @@ export function formatProfileList(profiles) {
     0
   )
 
+  /**
+   * @param {string} str
+   * @param {number} width
+   * @returns {string}
+   */
   const pad = (str, width) => str.padEnd(width, ' ')
 
   const lines = []
-
-  // header
   lines.push(`${pad('label', labelWidth)}  counter`)
 
-  // rows
   for (const p of sorted) {
     lines.push(`${pad(p.label, labelWidth)}  ${p.counter}`)
   }

--- a/src/models.js
+++ b/src/models.js
@@ -24,14 +24,6 @@
 
 /**
  * @typedef {{
- *   length: number,
- *   require: string[],
- *   symbolSet?: string
- * }} PasswordPolicyInput
- */
-
-/**
- * @typedef {{
  *   timeout?: number,
  *   sortBy?: ProfileSortField
  * }} Config
@@ -47,7 +39,9 @@
  *   save: boolean,
  *   create: string | null,
  *   deleteLabel: string | null,
- *   showProfileLabel: string | null
+ *   showProfileLabel: string | null,
+ *   configPresent: boolean,
+ *   configArg: string | null
  * }} CliArgs
  */
 
@@ -60,6 +54,8 @@
  *   promptForConfirmation?: (prompt: string) => Promise<string>,
  *   generatePassword?: (master: string, profile: Profile) => Promise<string>,
  *   copyToClipboard?: (text: string) => Promise<void>,
+ *   loadConfig?: () => Promise<Config>,
+ *   saveConfig?: (config: Config) => Promise<void>,
  *   stdout?: { write: (s: string) => void },
  *   stderr?: { write: (s: string) => void }
  * }} CliDeps

--- a/src/password.js
+++ b/src/password.js
@@ -1,12 +1,18 @@
 import { ByteStream } from './stream.js'
 import { uniformIndex } from './uniform.js'
 import { deterministicShuffle } from './shuffle.js'
-/** @typedef {import('./models.js').PasswordPolicyInput} PasswordPolicyInput */
+/** @typedef {import('./models.js').Profile} Profile */
+/** @typedef {import('./models.js').RequireClass} RequireClass */
 
 const LOWER = 'abcdefghijklmnopqrstuvwxyz'
 const UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 const DIGIT = '0123456789'
 
+/**
+ * @param {string} name
+ * @param {string} symbolSet
+ * @returns {string}
+ */
 function getClassAlphabet(name, symbolSet) {
   switch (name) {
     case 'lower':
@@ -22,7 +28,12 @@ function getClassAlphabet(name, symbolSet) {
   }
 }
 
+/**
+ * @param {RequireClass[]} require
+ * @returns {RequireClass[]}
+ */
 function canonicalRequire(require) {
+  /** @type RequireClass[] */
   const order = ['lower', 'upper', 'digit', 'symbol']
 
   for (const name of require) {
@@ -34,11 +45,22 @@ function canonicalRequire(require) {
   return order.filter(name => require.includes(name))
 }
 
+/**
+ * @param {RequireClass[]} require
+ * @param {string} symbolSet
+ * @returns {string}
+ */
 function buildAlphabet(require, symbolSet) {
   return canonicalRequire(require)
     .map(name => getClassAlphabet(name, symbolSet))
     .join('')
 }
+
+/**
+ * @param {ByteStream} stream
+ * @param {string} alphabet
+ * @returns {string}
+ */
 
 function pickChar(stream, alphabet) {
   return alphabet[uniformIndex(stream, alphabet.length)]
@@ -46,7 +68,7 @@ function pickChar(stream, alphabet) {
 
 /**
  * @param {Uint8Array} siteKey
- * @param {PasswordPolicyInput} profile
+ * @param {Profile} profile
  * @returns {string}
  */
 export function generatePasswordFromSiteKey(siteKey, profile) {
@@ -72,6 +94,7 @@ export function generatePasswordFromSiteKey(siteKey, profile) {
   }
 
   const stream = new ByteStream(siteKey)
+  /** @type string[] */
   const chars = []
 
   for (const className of require) {

--- a/src/prompt.js
+++ b/src/prompt.js
@@ -10,6 +10,7 @@ export function promptForMasterPassword() {
       output: process.stdout
     })
 
+    /** @type { (arg: string ) => void }*/
     const onData = char => {
       char = char + ''
       switch (char) {

--- a/src/shuffle.js
+++ b/src/shuffle.js
@@ -1,5 +1,11 @@
 import { uniformIndex } from './uniform.js'
+import { ByteStream } from './stream.js'
 
+/**
+ * @param {Array<string>} arr
+ * @param {ByteStream} stream
+ * @returns void
+ */
 export function deterministicShuffle(arr, stream) {
   for (let i = arr.length - 1; i > 0; i--) {
     const j = uniformIndex(stream, i + 1)

--- a/src/uniform.js
+++ b/src/uniform.js
@@ -1,3 +1,10 @@
+import { ByteStream } from './stream.js'
+
+/**
+ * @param {ByteStream} stream
+ * @param {number} n
+ * @returns {number}
+ */
 export function uniformIndex(stream, n) {
   if (n <= 0 || n > 256) {
     throw new Error('n must be between 1 and 256')

--- a/test/cli-args.test.js
+++ b/test/cli-args.test.js
@@ -1,145 +1,58 @@
-import { describe, it, expect } from 'vitest'
-import { parseArgs } from '../src/cli-args.js'
+import {describe, expect, it} from 'vitest'
+import {parseArgs} from '../src/cli-args.js'
+import {makeCliArgs} from "./fixtures/cli.js";
 
 describe('parseArgs', () => {
   it('parses -p <label>', () => {
-    expect(parseArgs(['-p', 'github-main'])).toEqual({
-      profileLabel: 'github-main',
-      show: false,
-      help: false,
-      bump: null,
-      list: false,
-      save: false,
-      create: null,
-      deleteLabel: null,
-      showProfileLabel: null
-    })
+    expect(parseArgs(['-p', 'github-main'])).toEqual(makeCliArgs({profileLabel: 'github-main'}))
   })
 
   it('parses --profile <label> --show', () => {
-    expect(parseArgs(['--profile', 'github-main', '--show'])).toEqual({
-      profileLabel: 'github-main',
-      show: true,
-      help: false,
-      bump: null,
-      list: false,
-      save: false,
-      create: null,
-      deleteLabel: null,
-      showProfileLabel: null
-    })
+    expect(parseArgs(['--profile', 'github-main', '--show'])).toEqual(makeCliArgs({profileLabel: 'github-main', show: true}))
   })
 
   it('parses -n <label>', () => {
-    expect(parseArgs(['-n', 'github-main'])).toEqual({
-      profileLabel: null,
-      show: false,
-      help: false,
-      list: false,
-      bump: null,
-      save: false,
-      create: 'github-main',
-      deleteLabel: null,
-      showProfileLabel: null
-    })
+    expect(parseArgs(['-n', 'github-main'])).toEqual(makeCliArgs({create: 'github-main'}))
   })
 
   it('parses --new <label>', () => {
-    expect(parseArgs(['--new', 'github-main'])).toEqual({
-      profileLabel: null,
-      show: false,
-      help: false,
-      list: false,
-      bump: null,
-      save: false,
-      create: 'github-main',
-      deleteLabel: null,
-      showProfileLabel: null
-    })
+    expect(parseArgs(['--new', 'github-main'])).toEqual(makeCliArgs({create: 'github-main'}))
   })
 
   it('parses -D <label>', () => {
-    expect(parseArgs(['-D', 'github-main'])).toEqual({
-      profileLabel: null,
-      show: false,
-      help: false,
-      list: false,
-      bump: null,
-      save: false,
-      create: null,
-      deleteLabel: 'github-main',
-      showProfileLabel: null
-    })
+    expect(parseArgs(['-D', 'github-main'])).toEqual(makeCliArgs({deleteLabel: 'github-main'}))
   })
 
   it('parses --delete <label>', () => {
-    expect(parseArgs(['--delete', 'github-main'])).toEqual({
-      profileLabel: null,
-      show: false,
-      help: false,
-      list: false,
-      bump: null,
-      save: false,
-      create: null,
-      deleteLabel: 'github-main',
-      showProfileLabel: null
-    })
+    expect(parseArgs(['--delete', 'github-main'])).toEqual(makeCliArgs({deleteLabel: 'github-main'}))
   })
 
   it('parses -b <label>', () => {
-    expect(parseArgs(['-b', 'github-main'])).toEqual({
-      profileLabel: null,
-      show: false,
-      help: false,
-      list: false,
-      bump: 'github-main',
-      save: false,
-      create: null,
-      deleteLabel: null,
-      showProfileLabel: null
-    })
+    expect(parseArgs(['-b', 'github-main'])).toEqual(makeCliArgs({bump: 'github-main'}))
   })
 
   it('parses --bump <label> --save --show', () => {
-    expect(parseArgs(['--bump', 'github-main', '--save', '--show'])).toEqual({
-      profileLabel: null,
-      show: true,
-      help: false,
-      list: false,
-      bump: 'github-main',
-      save: true,
-      create: null,
-      deleteLabel: null,
-      showProfileLabel: null
-    })
+    expect(parseArgs(['--bump', 'github-main', '--save', '--show'])).toEqual(makeCliArgs({show: true, bump: 'github-main', save: true}))
   })
 
   it('parses --show-profile <label>', () => {
-    expect(parseArgs(['--show-profile', 'github-main'])).toEqual({
-      profileLabel: null,
-      show: false,
-      help: false,
-      list: false,
-      bump: null,
-      save: false,
-      create: null,
-      deleteLabel: null,
-      showProfileLabel: 'github-main'
-    })
+    expect(parseArgs(['--show-profile', 'github-main'])).toEqual(makeCliArgs({showProfileLabel: 'github-main'}))
   })
 
   it('parses --help', () => {
-    expect(parseArgs(['--help'])).toEqual({
-      profileLabel: null,
-      show: false,
-      help: true,
-      bump: null,
-      list: false,
-      save: false,
-      create: null,
-      deleteLabel: null,
-      showProfileLabel: null
-    })
+    expect(parseArgs(['--help'])).toEqual(makeCliArgs({help: true}))
+  })
+
+  it('parses --config with no argument as show-config', () => {
+    expect(parseArgs(['--config'])).toEqual(makeCliArgs({configPresent: true}))
+  })
+
+  it('parses --config key=value', () => {
+    expect(parseArgs(['--config', 'timeout=900'])).toEqual(makeCliArgs({configPresent: true, configArg: 'timeout=900'}))
+  })
+
+  it('parses -c key=value', () => {
+    expect(parseArgs(['-c', 'sortBy=label'])).toEqual(makeCliArgs({configPresent: true, configArg: 'sortBy=label'}))
   })
 
   it('throws if profile label is missing after -p/--profile', () => {

--- a/test/cli-args.test.js
+++ b/test/cli-args.test.js
@@ -55,6 +55,14 @@ describe('parseArgs', () => {
     expect(parseArgs(['-c', 'sortBy=label'])).toEqual(makeCliArgs({configPresent: true, configArg: 'sortBy=label'}))
   })
 
+  it('parses -c --list', () => {
+    expect(parseArgs(['-c', '--list'])).toEqual(makeCliArgs({configPresent: true, list: true}))
+  })
+
+  it('throws if config argument is not in the form "key=value"', () => {
+    expect(() => parseArgs(['-c', 'fubar'])).toThrow(/key=value/i)
+  })
+
   it('throws if profile label is missing after -p/--profile', () => {
     expect(() => parseArgs(['-p'])).toThrow(/missing profile label/i)
     expect(() => parseArgs(['--profile'])).toThrow(/missing profile label/i)

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -519,6 +519,18 @@ describe('runCli', () => {
     expect(exitCode).toBe(1)
   })
 
+  it('fails if --config is used with --list', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, list: true }),
+      { stdout: { write: vi.fn() }, stderr }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/conflicting commands/i))
+  })
+
   it('shows current config as pretty JSON', async () => {
     const stdout = { write: vi.fn() }
 

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -7,6 +7,7 @@ import fs from 'node:fs/promises'
 import path from "node:path";
 import {tmpdir} from "node:os";
 import {loadAllProfiles, saveProfiles} from "../src/profiles-file.js";
+import { makeConfig } from './fixtures/config.js'
 /** @typedef {import('../src/models.js').Profile} Profile */
 
 describe('runCli', () => {
@@ -516,5 +517,108 @@ describe('runCli', () => {
     )
 
     expect(exitCode).toBe(1)
+  })
+
+  it('shows current config as pretty JSON', async () => {
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: null }),
+      {
+        loadConfig: async () => makeConfig({ timeout: 900 }),
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+
+    const output = stdout.write.mock.calls.map(c => c[0]).join('')
+    const parsed = JSON.parse(output)
+
+    expect(parsed).toEqual({
+      timeout: 900,
+      sortBy: 'label'
+    })
+  })
+
+  it('updates timeout config and persists it', async () => {
+    /** @type {import('../src/models.js').Config | null} */
+    let savedConfig = null
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: 'timeout=900' }),
+      {
+        loadConfig: async () => makeConfig(),
+        saveConfig: async config => { savedConfig = config },
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(savedConfig).toEqual({
+      timeout: 900,
+      sortBy: 'label'
+    })
+    expect(stdout.write).toHaveBeenCalledWith('Updated config: timeout=900\n')
+  })
+
+  it('updates sortBy config and persists it', async () => {
+    /** @type {import('../src/models.js').Config | null} */
+    let savedConfig = null
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: 'sortBy=label' }),
+      {
+        loadConfig: async () => makeConfig(),
+        saveConfig: async config => { savedConfig = config },
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(savedConfig).toEqual({
+      timeout: 0,
+      sortBy: 'label'
+    })
+    expect(stdout.write).toHaveBeenCalledWith('Updated config: sortBy=label\n')
+  })
+
+  it('fails for unknown config key', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: 'wat=x' }),
+      {
+        loadConfig: async () => makeConfig(),
+        saveConfig: async () => {},
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/unknown config key/i))
+  })
+
+  it('fails for invalid timeout', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: 'timeout=abc' }),
+      {
+        loadConfig: async () => makeConfig(),
+        saveConfig: async () => {},
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/invalid timeout/i))
   })
 })

--- a/test/config-file.test.js
+++ b/test/config-file.test.js
@@ -1,0 +1,100 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, it, expect } from 'vitest'
+import {
+  defaultConfig,
+  loadConfig,
+  saveConfig,
+  parseConfigAssignment,
+  applyConfigUpdate
+} from '../src/config-file.js'
+import { makeConfig } from './fixtures/config.js'
+
+describe('defaultConfig', () => {
+  it('returns the default config', () => {
+    expect(defaultConfig()).toEqual({
+      timeout: 0,
+      sortBy: 'label'
+    })
+  })
+})
+
+describe('loadConfig', () => {
+  it('returns default config when file is missing', async () => {
+    const configPath = path.join(tmpdir(), `dpg-missing-${Date.now()}.json`)
+    const config = await loadConfig({ configPath })
+    expect(config).toEqual(defaultConfig())
+  })
+})
+
+describe('parseConfigAssignment', () => {
+  it('parses timeout=900', () => {
+    expect(parseConfigAssignment('timeout=900')).toEqual({
+      key: 'timeout',
+      value: '900'
+    })
+  })
+
+  it('trims whitespace around key and value', () => {
+    expect(parseConfigAssignment(' timeout = 900 ')).toEqual({
+      key: 'timeout',
+      value: '900'
+    })
+  })
+
+  it('rejects missing value', () => {
+    expect(() => parseConfigAssignment('timeout=')).toThrow(/missing value/i)
+  })
+
+  it('rejects missing equals', () => {
+    expect(() => parseConfigAssignment('timeout')).toThrow(/key=value/i)
+  })
+})
+
+describe('applyConfigUpdate', () => {
+  it('updates timeout', () => {
+    expect(applyConfigUpdate(defaultConfig(), 'timeout', '900')).toEqual({
+      timeout: 900,
+      sortBy: 'label'
+    })
+  })
+
+  it('updates sortBy', () => {
+    expect(applyConfigUpdate(defaultConfig(), 'sortBy', 'label')).toEqual({
+      timeout: 0,
+      sortBy: 'label'
+    })
+  })
+
+  it('rejects unknown key', () => {
+    expect(() => applyConfigUpdate(defaultConfig(), 'wat', 'x')).toThrow(/unknown config key/i)
+  })
+
+  it('rejects invalid timeout', () => {
+    expect(() => applyConfigUpdate(defaultConfig(), 'timeout', 'abc')).toThrow(/invalid.*timeout/i)
+  })
+
+  it('rejects negative timeout', () => {
+    expect(() => applyConfigUpdate(defaultConfig(), 'timeout', '-1')).toThrow(/non-negative/i)
+  })
+
+  it('rejects unsupported sortBy', () => {
+    expect(() => applyConfigUpdate(defaultConfig(), 'sortBy', 'updatedAt')).toThrow(/unsupported.*sortBy/i)
+  })
+})
+
+describe('saveConfig', () => {
+  it('persists config using atomic write', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'dpg-config-'))
+    const configPath = path.join(dir, 'config.json')
+
+    await saveConfig(makeConfig({ timeout: 900 }), { configPath })
+
+    const text = await fs.readFile(configPath, 'utf8')
+    expect(JSON.parse(text)).toEqual({
+      timeout: 900,
+      sortBy: 'label'
+    })
+  })
+})

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,17 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import { encodeContext } from '../src/context.js'
+import { makeProfile } from './fixtures/profiles.js'
+/** @typedef {import('../src/models.js').RequireClass} RequireClass */
 
 describe('encodeContext', () => {
   it('encodes fields deterministically', () => {
-    const profile = {
-      version: 'dpg:v2',
-      service: 'github.com',
-      account: 'peter@example.com',
+    const profile = makeProfile({
       counter: 1,
       length: 20,
-      require: ['lower', 'upper', 'digit', 'symbol'],
       symbolSet: '!#$%&*+-=?@^_'
-    }
+    })
 
     const result = encodeContext(profile)
 
@@ -20,15 +18,12 @@ describe('encodeContext', () => {
   })
 
   it('is stable across calls', () => {
-    const profile = {
-      version: 'dpg:v2',
-      service: 'github.com',
+    const profile = makeProfile({
       account: '',
       counter: 1,
       length: 16,
-      require: ['lower', 'digit'],
-      symbolSet: '!@#'
-    }
+      require: ['lower', 'digit']
+    })
 
     const a = encodeContext(profile)
     const b = encodeContext(profile)
@@ -37,19 +32,19 @@ describe('encodeContext', () => {
   })
 
   it('normalizes require order', () => {
-    const p1 = {
-      version: 'dpg:v2',
+    const p1 = makeProfile({
       service: 'x',
       account: '',
       counter: 1,
       length: 10,
-      require: ['digit', 'upper'],
-      symbolSet: '!@#'
-    }
+      require: ['digit', 'upper']
+    })
 
+    /** @type {RequireClass[]} */
+    const newOrder = ['upper', 'digit']
     const p2 = {
       ...p1,
-      require: ['upper', 'digit']
+      require: newOrder
     }
 
     expect(Buffer.from(encodeContext(p1)))
@@ -57,15 +52,12 @@ describe('encodeContext', () => {
   })
 
   it('changes when service changes', () => {
-    const p1 = {
-      version: 'dpg:v2',
-      service: 'github.com',
+    const p1 = makeProfile({
       account: '',
       counter: 1,
       length: 16,
-      require: ['lower'],
-      symbolSet: '!@#'
-    }
+      require: ['lower']
+    })
 
     const p2 = {
       ...p1,
@@ -77,15 +69,12 @@ describe('encodeContext', () => {
   })
 
   it('changes when counter changes', () => {
-    const p1 = {
-      version: 'dpg:v2',
-      service: 'github.com',
+    const p1 = makeProfile({
       account: '',
       counter: 1,
       length: 16,
-      require: ['lower'],
-      symbolSet: '!@#'
-    }
+      require: ['lower']
+    })
 
     const p2 = {
       ...p1,
@@ -95,6 +84,5 @@ describe('encodeContext', () => {
     expect(Array.from(encodeContext(p1)))
       .not.toEqual(Array.from(encodeContext(p2)))
   })
-
 })
 

--- a/test/fixtures/cli.js
+++ b/test/fixtures/cli.js
@@ -15,6 +15,8 @@ export function makeCliArgs(overrides = {}) {
     create: null,
     deleteLabel: null,
     showProfileLabel: null,
+    configPresent: false,
+    configArg: null,
     ...overrides
   }
 }

--- a/test/fixtures/config.js
+++ b/test/fixtures/config.js
@@ -1,0 +1,18 @@
+/** @typedef {import('../../src/models.js').Config} Config */
+
+/** @type {Config} */
+export const DEFAULT_CONFIG = {
+  timeout: 0,
+  sortBy: 'label'
+}
+
+/**
+ * @param {Partial<Config>=} overrides
+ * @returns {Config}
+ */
+export function makeConfig(overrides = {}) {
+  return {
+    ...DEFAULT_CONFIG,
+    ...overrides
+  }
+}

--- a/test/password.test.js
+++ b/test/password.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { generatePasswordFromSiteKey } from '../src/password.js'
+import {makeProfile} from "./fixtures/profiles.js";
 
 function fixedSiteKey() {
   return new Uint8Array(32).fill(11)
@@ -7,21 +8,21 @@ function fixedSiteKey() {
 
 describe('generatePasswordFromSiteKey', () => {
   it('generates a password of the requested length', () => {
-    const password = generatePasswordFromSiteKey(fixedSiteKey(), {
+    const password = generatePasswordFromSiteKey(fixedSiteKey(), makeProfile({
       length: 16,
       require: ['lower', 'upper', 'digit', 'symbol'],
       symbolSet: '!@#'
-    })
+    }))
 
     expect(password).toHaveLength(16)
   })
 
   it('is deterministic for the same site key and profile', () => {
-    const profile = {
+    const profile = makeProfile({
       length: 20,
       require: ['lower', 'upper', 'digit', 'symbol'],
       symbolSet: '!@#'
-    }
+    })
 
     const a = generatePasswordFromSiteKey(fixedSiteKey(), profile)
     const b = generatePasswordFromSiteKey(fixedSiteKey(), profile)
@@ -30,11 +31,11 @@ describe('generatePasswordFromSiteKey', () => {
   })
 
   it('contains at least one character from each required class', () => {
-    const password = generatePasswordFromSiteKey(fixedSiteKey(), {
+    const password = generatePasswordFromSiteKey(fixedSiteKey(), makeProfile({
       length: 24,
       require: ['lower', 'upper', 'digit', 'symbol'],
       symbolSet: '!@#'
-    })
+    }))
 
     expect(password).toMatch(/[a-z]/)
     expect(password).toMatch(/[A-Z]/)
@@ -43,50 +44,52 @@ describe('generatePasswordFromSiteKey', () => {
   })
 
   it('uses only allowed characters', () => {
-    const password = generatePasswordFromSiteKey(fixedSiteKey(), {
+    const password = generatePasswordFromSiteKey(fixedSiteKey(), makeProfile({
       length: 50,
       require: ['lower', 'digit'],
       symbolSet: '!@#'
-    })
+    }))
 
     expect(password).toMatch(/^[a-z0-9]+$/)
   })
 
   it('throws if length is less than number of required classes', () => {
     expect(() =>
-      generatePasswordFromSiteKey(fixedSiteKey(), {
+      generatePasswordFromSiteKey(fixedSiteKey(), makeProfile({
         length: 2,
         require: ['lower', 'upper', 'digit'],
         symbolSet: '!@#'
-      })
+      }))
     ).toThrow(/length/i)
   })
 
   it('throws if no character classes are enabled', () => {
     expect(() =>
-      generatePasswordFromSiteKey(fixedSiteKey(), {
+      generatePasswordFromSiteKey(fixedSiteKey(), makeProfile({
         length: 10,
         require: [],
         symbolSet: '!@#'
-      })
+      }))
     ).toThrow(/character class|alphabet/i)
   })
 
   it('throws on unknown character class', () => {
+
     expect(() =>
-      generatePasswordFromSiteKey(fixedSiteKey(), {
+      generatePasswordFromSiteKey(fixedSiteKey(), makeProfile({
         length: 10,
-        require: ['lower', 'runes'],
+        require: ['lower', /* @ts-ignore */
+          'runes'],
         symbolSet: '!@#'
-      })
+      }))
     ).toThrow(/unknown/i)
   })
 
   it('defaults symbolSet when symbols are required', () => {
-    const password = generatePasswordFromSiteKey(fixedSiteKey(), {
+    const password = generatePasswordFromSiteKey(fixedSiteKey(), makeProfile({
       length: 20,
       require: ['symbol']
-    })
+    }))
 
     expect(password).toHaveLength(20)
   })


### PR DESCRIPTION
## Add basic config support (`--config`)

Introduces CLI support for viewing and updating application config.

### Features
- `dpg --config` prints current config as pretty-printed JSON
- `dpg --config key=value` updates a single config value
- supported keys:
  - `timeout` (non-negative integer)
  - `sortBy` (currently `label`)

### Behavior
- config is persisted using atomic writes
- missing config file is handled by returning defaults
- clear validation errors for invalid keys/values

### Integration
- `sortBy` is respected by `--list`

### Tests
- added coverage for show/update/validation flows
- integration tests updated to cover config behavior

### Notes
- implementation is intentionally minimal (v1 scope)
- includes minor test cleanup using `makeProfile` fixture

All tests passing, no regressions.