### PR TITLE
DPG-020: Add integration test harness, test split, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,5 @@ jobs:
       - name: Link local CLI
         run: npm link
 
-      - name: Make integration runner executable
-        run: chmod +x integration/run.sh
-
       - name: Run TSV integration harness
         run: ./integration/run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Run full Vitest suite
         run: npm run test:all
 
+      - name: Link local CLI
+        run: npm link
+
       - name: Make integration runner executable
         run: chmod +x integration/run.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,9 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run full Vitest suite
+        run: npm run test:all
+
+      - name: Make integration runner executable
+        run: chmod +x integration/run.sh
+
+      - name: Run TSV integration harness
+        run: ./integration/run.sh

--- a/README.md
+++ b/README.md
@@ -292,6 +292,20 @@ The test suite uses two modes:
 
 This keeps development fast while still verifying the real KDF path.
 
+### Test suites
+
+- `npm test` — fast tests (includes golden regression checks)
+- `npm run test:slow` — slow tests only
+- `npm run test:all` — full test suite
+
+## Integration test harness
+
+A lightweight TSV-driven CLI integration harness lives in `integration/`.
+
+Run it with:
+
+    ./integration/run.sh
+
 ---
 
 ## 🧭 Project goals

--- a/integration/config.json
+++ b/integration/config.json
@@ -1,0 +1,4 @@
+{
+  "timeout": 90,
+  "sortBy": "label"
+}

--- a/integration/fake-bin/xclip
+++ b/integration/fake-bin/xclip
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Fake xclip for integration tests (CI-friendly)
+
+# Consume stdin and do nothing
+cat >/dev/null
+
+exit 0

--- a/integration/profiles.json
+++ b/integration/profiles.json
@@ -1,0 +1,13 @@
+[
+  {
+    "version":"dpg:v2",
+    "label":"github-main",
+    "service":"github.com",
+    "counter":4,
+    "length":20,
+    "require":["lower","upper","digit","symbol"],
+    "symbolSet":"!@#",
+    "createdAt":"2026-04-20T00:00:00.000Z",
+    "updatedAt":"2026-04-20T00:00:00.000Z"
+  }
+]

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -62,7 +62,19 @@ match_output() {
   esac
 }
 
-trap restore_files EXIT
+cleanup() {
+  restore_files
+  rm -rf "$FAKE_BIN_DIR"
+}
+
+trap cleanup EXIT
+
+FAKE_BIN_DIR="$(mktemp -d)"
+
+cp "${SCRIPT_DIR}/fake-bin/xclip" "${FAKE_BIN_DIR}/xclip"
+chmod +x "${FAKE_BIN_DIR}/xclip"
+
+export PATH="${FAKE_BIN_DIR}:$PATH"
 
 mkdir -p "$DPG_DIR"
 

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+GREEN="\033[0;32m"
+RED="\033[0;31m"
+RESET="\033[0m"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DPG_DIR="${HOME}/.dpg-v2"
+PROFILES_FILE="${DPG_DIR}/profiles.json"
+CONFIG_FILE="${DPG_DIR}/config.json"
+
+PROFILES_BACKUP_FILE="${DPG_DIR}/profiles.json.bak.integration"
+CONFIG_BACKUP_FILE="${DPG_DIR}/config.json.bak.integration"
+
+restore_files() {
+  if [[ -f "$PROFILES_BACKUP_FILE" ]]; then
+    mv -f "$PROFILES_BACKUP_FILE" "$PROFILES_FILE"
+    echo
+    echo "Restored original profiles.json"
+  else
+    rm -f "$PROFILES_FILE"
+    echo
+    echo "Removed test profiles.json"
+  fi
+
+  if [[ -f "$CONFIG_BACKUP_FILE" ]]; then
+    mv -f "$CONFIG_BACKUP_FILE" "$CONFIG_FILE"
+    echo "Restored original config.json"
+  else
+    rm -f "$CONFIG_FILE"
+    echo "Removed test config.json"
+  fi
+}
+
+match_output() {
+  local mode="$1"
+  local expected="$2"
+  local actual="$3"
+
+  if [[ "$expected" == "-" ]]; then
+    expected=""
+  fi
+
+  case "$mode" in
+    exact)
+      [[ "$actual" == "$expected" ]]
+      ;;
+    contains)
+      [[ "$actual" == *"$expected"* ]]
+      ;;
+    *)
+      echo "Unknown match mode: $mode" >&2
+      return 2
+      ;;
+  esac
+}
+
+trap restore_files EXIT
+
+mkdir -p "$DPG_DIR"
+
+if [[ -f "$PROFILES_FILE" ]]; then
+  mv -f "$PROFILES_FILE" "$PROFILES_BACKUP_FILE"
+  echo "Backed up existing profiles.json"
+else
+  echo "No existing profiles.json found; test suite will create its own"
+fi
+
+if [[ -f "$CONFIG_FILE" ]]; then
+  mv -f "$CONFIG_FILE" "$CONFIG_BACKUP_FILE"
+  echo "Backed up existing config.json"
+else
+  echo "No existing config.json found; test suite will create its own"
+fi
+
+cp "${SCRIPT_DIR}/profiles.json" "$PROFILES_FILE"
+cp "${SCRIPT_DIR}/config.json" "$CONFIG_FILE"
+
+echo "Running integration tests..."
+echo
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+IFS=$'\t' read -r name cmd stdin expected_exit stdout_match expected_stdout stderr_match expected_stderr <<< "$line"
+
+if [[ -z "$stdout_match" || -z "$stderr_match" ]]; then
+  echo -e "${RED}FAIL${RESET}: malformed TSV row"
+  echo "$line"
+  ((FAIL++))
+  echo
+  continue
+fi
+
+  echo "→ $name"
+
+stdout_file="$(mktemp)"
+stderr_file="$(mktemp)"
+
+if [[ "$stdin" != "-" ]]; then
+  printf '%s\n' "$stdin" | eval "$cmd" >"$stdout_file" 2>"$stderr_file"
+  exit_code=$?
+else
+  eval "$cmd" >"$stdout_file" 2>"$stderr_file"
+  exit_code=$?
+fi
+
+stdout_content="$(cat "$stdout_file")"
+stderr_content="$(cat "$stderr_file")"
+
+rm -f "$stdout_file" "$stderr_file"
+
+if [[ "$exit_code" != "$expected_exit" ]]; then
+  echo -e "${RED}FAIL${RESET}: expected exit $expected_exit, got $exit_code"
+  echo "stdout:"
+  echo "$stdout_content"
+  echo "stderr:"
+  echo "$stderr_content"
+  ((FAIL++))
+  echo
+  continue
+fi
+
+if ! match_output "$stdout_match" "$expected_stdout" "$stdout_content"; then
+  echo -e "${RED}FAIL${RESET}: stdout mismatch ($stdout_match)"
+  echo "Expected stdout:"
+  echo "$expected_stdout"
+  echo "Actual stdout:"
+  echo "$stdout_content"
+  ((FAIL++))
+  echo
+  continue
+fi
+
+if ! match_output "$stderr_match" "$expected_stderr" "$stderr_content"; then
+  echo -e "${RED}FAIL${RESET}: stderr mismatch ($stderr_match)"
+  echo "Expected stderr:"
+  echo "$expected_stderr"
+  echo "Actual stderr:"
+  echo "$stderr_content"
+  ((FAIL++))
+  echo
+  continue
+fi
+
+echo -e "${GREEN}PASS${RESET}"
+((PASS++))
+echo
+
+done < <(tail -n +2 "${SCRIPT_DIR}/tests.tsv")
+
+echo "Summary: $PASS passed, $FAIL failed"
+
+if [[ "$FAIL" -ne 0 ]]; then
+  exit 1
+fi

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -99,6 +99,7 @@ echo "Running integration tests..."
 echo
 
 while IFS= read -r line || [[ -n "$line" ]]; do
+[[ -z "$line" || "$line" == \#* ]] && continue
 IFS=$'\t' read -r name cmd stdin expected_exit stdout_match expected_stdout stderr_match expected_stderr <<< "$line"
 
 if [[ -z "$stdout_match" || -z "$stderr_match" ]]; then

--- a/integration/tests.tsv
+++ b/integration/tests.tsv
@@ -1,0 +1,18 @@
+name	command	stdin	expected_exit	stdout_match	expected_stdout	stderr_match	expected_stderr
+list-nonempty	dpg --list	-	0	contains	github-main	exact	-
+missing-command	dpg	-	1	exact	-	exact	No command specified. See -h for help.
+unknown-flag	dpg --shwo	-	1	exact	-	exact	Unknown argument: --shwo
+bump-no-save	dpg -b github-main	password123	0	contains	Counter:	exact	-
+bump-with-save	dpg -b github-main --save	password123	0	contains	(saved)	exact	-
+invalid-combo	dpg --list --show	-	1	exact	-	contains	--show is only valid with --profile or --bump
+missing-label	dpg -b	-	1	exact	-	contains	Missing profile label after -b/--bump
+weird-order	dpg github-main -b	-	1	exact	-	contains	Unknown argument: github-main
+config-sortby	dpg --config sortBy=label	-	0	contains	Updated config: sortBy=label	exact	-
+config-bad-arg	dpg --config fubar	-	1	exact	-	contains	Config update must use key=value syntax
+config-bad-key	dpg --config wat=x	-	1	exact	-	contains	Unknown config key
+config-bad-timeout	dpg --config timeout=abc	-	1	exact	-	contains	Invalid timeout
+config-unsupported	dpg --config sortBy=foo	-	1	exact	-	contains	Unsupported sortBy value: 'foo'
+config-show	dpg --config	-	0	contains	"sortBy": "label"	exact	-
+config-timeout	dpg --config timeout=900	-	0	contains	Updated config: timeout=900	exact	-
+config-show-updated	dpg --config	-	0	contains	"timeout": 900	exact	-
+show-profile	dpg --show-profile github-main	-	0	contains	"label": "github-main"	exact	-

--- a/integration/tests.tsv
+++ b/integration/tests.tsv
@@ -1,4 +1,8 @@
 name	command	stdin	expected_exit	stdout_match	expected_stdout	stderr_match	expected_stderr
+
+# NOTE: Test cases are order-dependent.
+# Some tests rely on state changes from earlier rows (e.g. config updates).
+
 list-nonempty	dpg --list	-	0	contains	github-main	exact	-
 missing-command	dpg	-	1	exact	-	exact	No command specified. See -h for help.
 unknown-flag	dpg --shwo	-	1	exact	-	exact	Unknown argument: --shwo

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "type": "module",
   "scripts": {
-    "test": "vitest run --exclude 'test/**/*.slow.test.js'",
+    "test": "vitest --exclude 'test/**/*.slow.test.js'",
     "test:slow": "vitest run test/kdf.slow.test.js test/generate.slow.test.js --reporter=verbose",
     "test:all": "vitest run --reporter=verbose"
   },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   },
   "type": "module",
   "scripts": {
-    "test": "vitest",
-    "test:verbose": "vitest --reporter=verbose",
-    "test:slow": "vitest -t \"\\[slow\\]\" --reporter=verbose"
+    "test": "vitest run --exclude 'test/**/*.slow.test.js'",
+    "test:slow": "vitest run test/kdf.slow.test.js test/generate.slow.test.js --reporter=verbose",
+    "test:all": "vitest run --reporter=verbose"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/test/generate.slow.test.js
+++ b/test/generate.slow.test.js
@@ -1,0 +1,15 @@
+import {describe, expect, it} from 'vitest'
+import {generatePassword} from '../src/generate.js'
+import {DEFAULT_PROFILE} from './fixtures/profiles.js'
+
+describe('generatePassword (production Argon2)', () => {
+  it('works end-to-end with production Argon2 parameters [slow]', async () => {
+    const password = await generatePassword('master', DEFAULT_PROFILE)
+
+    expect(password).toHaveLength(DEFAULT_PROFILE.length)
+    expect(password).toMatch(/[a-z]/)
+    expect(password).toMatch(/[A-Z]/)
+    expect(password).toMatch(/[0-9]/)
+    expect(password).toMatch(/[!@#]/)
+  })
+})

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -48,21 +48,11 @@ describe('generatePassword', () => {
 
 })
 
-describe('generatePassword (production Argon2)', () => {
-  it('works end-to-end with production Argon2 parameters [slow]', async () => {
-    const password = await generatePassword('master', DEFAULT_PROFILE)
-
-    expect(password).toHaveLength(DEFAULT_PROFILE.length)
-    expect(password).toMatch(/[a-z]/)
-    expect(password).toMatch(/[A-Z]/)
-    expect(password).toMatch(/[0-9]/)
-    expect(password).toMatch(/[!@#]/)
-  })
-
+describe('generatePassword (Golden test using production Argon2)', () => {
   // Golden test. If this fails, either:
   // 1) you improved the algorithm (unlikely), or
   // 2) you broke something (more likely)
-  it('[golden] produces expected password for known inputs', async () => {
+  it('produces expected password for known inputs [golden|slow]', async () => {
     const profile = {
       version: 'dpg:v2',
       label: 'andrew-test',
@@ -78,7 +68,6 @@ describe('generatePassword (production Argon2)', () => {
       'Walking Thoughts',
       profile
     )
-
     // Golden test: if this changes, the derivation behavior changed.
     expect(password).toBe('u)L]y5e}9X{WwUD)')
   })

--- a/test/kdf.slow.test.js
+++ b/test/kdf.slow.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { deriveSiteKey } from '../src/kdf.js'
+import { encodeContext } from '../src/context.js'
+import { DEFAULT_PROFILE  } from './fixtures/profiles.js'
+
+describe('deriveSiteKey (production Argon2)', () => {
+  it('works with production Argon2 parameters [slow]', async () => {
+    const context = encodeContext(DEFAULT_PROFILE)
+
+    const key = await deriveSiteKey('master', context)
+
+    expect(key).toBeInstanceOf(Uint8Array)
+    expect(key).toHaveLength(32)
+  })
+})

--- a/test/kdf.test.js
+++ b/test/kdf.test.js
@@ -63,14 +63,3 @@ describe('deriveSiteKey', () => {
 
 })
 
-describe('deriveSiteKey (production Argon2)', () => {
-  it('works with production Argon2 parameters [slow]', async () => {
-    const context = encodeContext(DEFAULT_PROFILE)
-
-    const key = await deriveSiteKey('master', context)
-
-    expect(key).toBeInstanceOf(Uint8Array)
-    expect(key).toHaveLength(32)
-  })
-
-})


### PR DESCRIPTION
## Add integration test harness, test split, and CI

This PR introduces a lightweight TSV-driven CLI integration test harness and improves test execution structure.

### Integration harness
- adds `integration/run.sh` and TSV test suite
- executes CLI commands end-to-end
- supports stdin, exit codes, stdout/stderr separation
- supports match modes (`contains`, `exact`)
- safely backs up and restores local profiles and config

### Test structure
- splits slow tests into `*.slow.test.js`
- keeps fast + golden tests in default suite
- adds scripts:
  - `npm test` (fast + golden)
  - `npm run test:slow`
  - `npm run test:all`

### CI
- adds GitHub Actions workflow
- runs full test suite and integration harness on push and pull requests

### Notes
- harness is intentionally simple and extensible
- no changes to application behavior
- all tests passing locally and in CI