### PR TITLE
DPG-019 Normalize require array ordering

### DIFF
--- a/src/password.js
+++ b/src/password.js
@@ -34,15 +34,15 @@ function getClassAlphabet(name, symbolSet) {
  */
 export function canonicalRequire(require) {
   /** @type RequireClass[] */
-  const order = ['lower', 'upper', 'digit', 'symbol']
+  const ORDER = ['lower', 'upper', 'digit', 'symbol']
 
   for (const name of require) {
-    if (!order.includes(name)) {
+    if (!ORDER.includes(name)) {
       throw new Error(`Unknown character class: ${name}`)
     }
   }
 
-  return order.filter(name => require.includes(name))
+  return ORDER.filter(name => require.includes(name))
 }
 
 /**

--- a/test/profile-validation.test.js
+++ b/test/profile-validation.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { validateProfileLabel } from '../src/profile-validation.js'
+import {canonicalRequire} from "../src/password.js";
 
 describe('validateProfileLabel', () => {
   it('accepts simple labels', () => {
@@ -19,5 +20,30 @@ describe('validateProfileLabel', () => {
 
   it('rejects labels with spaces', () => {
     expect(() => validateProfileLabel('github main')).toThrow(/invalid profile label/i)
+  })
+
+  it('orders require values canonically', () => {
+    expect(canonicalRequire(['symbol', 'lower', 'digit'])).toEqual([
+      'lower',
+      'digit',
+      'symbol'
+    ])
+  })
+
+  it('keeps canonical order unchanged', () => {
+    expect(canonicalRequire(['lower', 'upper', 'digit', 'symbol']))
+      .toEqual(['lower', 'upper', 'digit', 'symbol'])
+  })
+
+  it('normalizes different input orders to the same output', () => {
+    const a = canonicalRequire(['symbol', 'lower'])
+    const b = canonicalRequire(['lower', 'symbol'])
+
+    expect(a).toEqual(b)
+  })
+
+  it('deduplicates and orders require values', () => {
+    expect(canonicalRequire(['upper', 'lower', 'upper']))
+      .toEqual(['lower', 'upper'])
   })
 })


### PR DESCRIPTION
# Normalize `require` array ordering

## Summary  
Ensure that the `require` field is treated as a set with a canonical ordering to guarantee deterministic profile output.

## Changes  
- Add tests verifying that `require` values are always ordered as:  
  `lower, upper, digit, symbol`  
- Confirm that existing `canonicalRequire` implementation already enforces this ordering

## Behavior  
- Input order does not matter  
- Stored and displayed order is always canonical  
- No changes to existing functionality

## Testing  
- Added unit tests for ordering, normalization, and determinism  
- All existing tests passing

## Notes  
This change improves determinism and test stability without requiring any code changes.

---

## 🧓 One-line summary  

Trust, but verify — and it was already correct.
