### PR TITLE
DPG-030: Normalize TSV quoting and escape handling

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,169 @@
+# Integration Tests (TSV Harness)
+
+Welcome to the integration test suite for **dpg-cli**.
+
+These tests verify end-to-end CLI behavior using a simple, declarative format based on **TSV (tab-separated values)**. Each row represents a complete test case: command, input, expectations, and exit code.
+
+The goal is to keep tests:
+- easy to read
+- easy to write
+- easy to extend
+- and robust across environments
+
+---
+
+## 🧠 Philosophy
+
+This is not a general-purpose test framework.
+
+It is a **small, purpose-built DSL** for testing CLI behavior with minimal ceremony and maximum clarity.
+
+> Prefer clarity over cleverness, and explicit behavior over implicit magic.
+
+---
+
+## 📋 File format
+
+Each test is a single TSV row with the following columns:
+
+| Column            | Description                                  |
+|------------------|----------------------------------------------|
+| name             | Unique test identifier                       |
+| command          | CLI command to execute                       |
+| stdin            | Input to pass via stdin (`-` = none)         |
+| exit             | Expected exit code                           |
+| stdout mode      | `exact` or `contains`                        |
+| stdout expected  | Expected stdout content                      |
+| stderr mode      | `exact` or `contains`                        |
+| stderr expected  | Expected stderr content                      |
+
+Example:
+
+```
+list-basic	dpg-cli --list	-	0	contains	github-main	exact	-
+```
+
+---
+
+## 🔤 Escaping rules
+
+To keep the TSV file tool-friendly (GitHub, IntelliJ), we avoid literal quotes and special characters.
+
+Instead, we use a minimal escape system:
+
+| Sequence | Meaning        |
+|----------|----------------|
+| `\q`     | `"` (quote)    |
+| `\n`     | newline        |
+
+Example:
+
+```
+contains	\qsortBy\q: \qlabel\q
+```
+
+This will be interpreted by the harness as:
+
+```json
+"sortBy": "label"
+```
+
+Multiline example:
+
+```
+exact	line1\nline2
+```
+
+---
+
+## ⚙️ Command field
+
+Commands are written as they would be typed in the shell.
+
+If arguments contain spaces, wrap them using `\q`:
+
+```
+dpg-cli --config \qeditor=vi -f\q
+```
+
+The harness will unescape this before execution.
+
+---
+
+## 📥 stdin handling
+
+- Use `-` to indicate no stdin
+- Otherwise, provide input (supports `\n`)
+
+Example:
+
+```
+some-test	dpg-cli --command	password123	0	exact	...	exact	-
+```
+
+stdin is passed with a trailing newline, matching typical terminal behavior.
+
+---
+
+## 🔍 Matching modes
+
+### `exact`
+Output must match exactly (after normalization).
+
+### `contains`
+Output must contain the expected string.
+
+Examples:
+
+```
+exact	Success
+contains	github.com
+```
+
+---
+
+## 🧪 Writing tests
+
+### Keep tests simple
+Each row should express one behavior clearly.
+
+### Prefer `contains` unless format is critical
+Use `exact` only when the full output structure matters.
+
+### Use real CLI output when possible
+Avoid constructing artificial outputs — match what the tool actually produces.
+
+---
+
+## 🧹 Style guidelines
+
+- No literal quotes (`"`); always use `\q`
+- Keep rows readable — this file is meant to be scanned by humans
+- Avoid clever tricks; explicit is better
+- Group related tests together logically
+
+---
+
+## 🧓 Notes from the Grumpy Code Reviewer
+
+- If your test needs five backslashes, your test is wrong
+- If tools complain, either ignore them intentionally — or fix the format
+- Tests should be boring, predictable, and hard to break
+
+---
+
+## 🚀 Why this exists
+
+This harness gives us:
+
+- fast feedback
+- strong regression protection
+- confidence when refactoring
+- a clear, executable specification of CLI behavior
+
+And now — thanks to normalized escaping — it also plays nicely with editors and tooling.
+
+---
+
+Happy testing 👣
+```

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -38,9 +38,22 @@ restore_files() {
   fi
 }
 
+unescape() {
+  local s="$1"
+
+  # Custom TSV escapes:
+  # \n -> newline
+  # \q -> double quote
+  s="${s//\\n/$'\n'}"
+  s="${s//\\q/\"}"
+
+  printf "%s" "$s"
+}
+
 match_output() {
   local mode="$1"
-  local expected="$2"
+  local expected
+  expected="$(unescape "$2")"
   local actual="$3"
 
   if [[ "$expected" == "-" ]]; then
@@ -111,11 +124,14 @@ fi
 
   echo "→ $name"
 
+stdin_file="$(mktemp)"
 stdout_file="$(mktemp)"
 stderr_file="$(mktemp)"
+cmd="$(unescape "$cmd")"
 
 if [[ "$stdin" != "-" ]]; then
-  printf '%s\n' "$stdin" | eval "$cmd" >"$stdout_file" 2>"$stderr_file"
+  printf '%s\n' "$(unescape "$stdin")" > "$stdin_file"
+  eval "$cmd" < "$stdin_file" >"$stdout_file" 2>"$stderr_file"
   exit_code=$?
 else
   eval "$cmd" >"$stdout_file" 2>"$stderr_file"
@@ -125,7 +141,7 @@ fi
 stdout_content="$(cat "$stdout_file")"
 stderr_content="$(cat "$stderr_file")"
 
-rm -f "$stdout_file" "$stderr_file"
+rm -f "$stdin_file" "$stdout_file" "$stderr_file"
 
 if [[ "$exit_code" != "$expected_exit" ]]; then
   echo -e "${RED}FAIL${RESET}: expected exit $expected_exit, got $exit_code"

--- a/integration/tests.tsv
+++ b/integration/tests.tsv
@@ -1,28 +1,32 @@
 name	command	stdin	expected_exit	stdout_match	expected_stdout	stderr_match	expected_stderr
-# NOTE:	TSV uses the following custom escapes:	-	-	-	\q → doublequote,  \n → newline	-	-
-# NOTE:	Test cases are order-dependent:	-	-	-	and may rely on state changes from earlier rows (e.g. config updates).	-	-
 
 quote-escape	dpg-cli --config	-	0	contains	\qsortBy\q: \qlabel\q	exact	-
-missing-command	dpg-cli	-	1	exact	-	exact	No command specified. See -h for help.
 show-help	dpg-cli -h	-	0	contains	Usage	exact	-
+
 list-nonempty	dpg-cli --list	-	0	contains	github-main	exact	-
 list-exact	dpg-cli --list	-	0	exact	label        counter\ngithub-main  4	exact	-
+
+missing-command	dpg-cli	-	1	exact	-	exact	No command specified. See -h for help.
 unknown-flag	dpg-cli --shwo	-	1	exact	-	exact	Unknown argument: --shwo
-bump-no-save	dpg-cli -b github-main	password123	0	contains	Counter:	exact	-
-bump-with-save	dpg-cli -b github-main --save	password123	0	contains	(saved)	exact	-
 invalid-combo	dpg-cli --list --show	-	1	exact	-	contains	--show is only valid with --profile or --bump
 missing-label	dpg-cli -b	-	1	exact	-	contains	Missing profile label after -b/--bump
 weird-order	dpg-cli github-main -b	-	1	exact	-	contains	Unknown argument: github-main
+
+bump-no-save	dpg-cli -b github-main	password123	0	contains	Counter:	exact	-
+bump-with-save	dpg-cli -b github-main --save	password123	0	contains	(saved)	exact	-
+
 config-show	dpg-cli --config	-	0	contains	\qsortBy\q: \qlabel\q	exact	-
 config-sortby	dpg-cli --config sortBy=label	-	0	contains	Updated config: sortBy=label	exact	-
 config-unsupported	dpg-cli --config sortBy=foo	-	1	exact	-	contains	Unsupported sortBy value: 'foo'
 config-timeout	dpg-cli --config timeout=900	-	0	contains	Updated config: timeout=900	exact	-
+config-show-updated	dpg-cli --config	-	0	contains	\qtimeout\q: 900	exact	-
 config-bad-timeout	dpg-cli --config timeout=abc	-	1	exact	-	contains	Invalid timeout
 config-editor	dpg-cli --config editor=nano	-	0	contains	Updated config: editor=nano	exact	-
 config-bad-key	dpg-cli --config wat=x	-	1	exact	-	contains	Unknown config key
 config-bad-arg	dpg-cli --config fubar	-	1	exact	-	contains	Config update must use key=value syntax
-config-show-updated	dpg-cli --config	-	0	contains	\qtimeout\q: 900	exact	-
-show-profile	dpg-cli --show-profile github-main	-	0	contains	\qlabel\q: \qgithub-main\q	exact	-
-edit-missing	dpg-cli --edit foobar	-	1	exact	-	contains	Profile not found: foobar
 config-editor-with-args	dpg-cli --config \qeditor=vi -f\q	-	0	contains	Updated config: editor=vi -f	exact	-
 config-show-editor-with-args	dpg-cli --config	-	0	contains	\qeditor\q: \qvi -f\q	exact	-
+
+show-profile	dpg-cli --show-profile github-main	-	0	contains	\qlabel\q: \qgithub-main\q	exact	-
+
+edit-missing	dpg-cli --edit foobar	-	1	exact	-	contains	Profile not found: foobar

--- a/integration/tests.tsv
+++ b/integration/tests.tsv
@@ -1,18 +1,19 @@
 name	command	stdin	expected_exit	stdout_match	expected_stdout	stderr_match	expected_stderr
+# NOTE:	TSV uses the following custom escapes:	-	-	-	\q → doublequote,  \n → newline	-	-
+# NOTE:	Test cases are order-dependent:	-	-	-	and may rely on state changes from earlier rows (e.g. config updates).	-	-
 
-# NOTE: Test cases are order-dependent.
-# Some tests rely on state changes from earlier rows (e.g. config updates).
-
+quote-escape	dpg-cli --config	-	0	contains	\qsortBy\q: \qlabel\q	exact	-
 missing-command	dpg-cli	-	1	exact	-	exact	No command specified. See -h for help.
 show-help	dpg-cli -h	-	0	contains	Usage	exact	-
 list-nonempty	dpg-cli --list	-	0	contains	github-main	exact	-
+list-exact	dpg-cli --list	-	0	exact	label        counter\ngithub-main  4	exact	-
 unknown-flag	dpg-cli --shwo	-	1	exact	-	exact	Unknown argument: --shwo
 bump-no-save	dpg-cli -b github-main	password123	0	contains	Counter:	exact	-
 bump-with-save	dpg-cli -b github-main --save	password123	0	contains	(saved)	exact	-
 invalid-combo	dpg-cli --list --show	-	1	exact	-	contains	--show is only valid with --profile or --bump
 missing-label	dpg-cli -b	-	1	exact	-	contains	Missing profile label after -b/--bump
 weird-order	dpg-cli github-main -b	-	1	exact	-	contains	Unknown argument: github-main
-config-show	dpg-cli --config	-	0	contains	"sortBy": "label"	exact	-
+config-show	dpg-cli --config	-	0	contains	\qsortBy\q: \qlabel\q	exact	-
 config-sortby	dpg-cli --config sortBy=label	-	0	contains	Updated config: sortBy=label	exact	-
 config-unsupported	dpg-cli --config sortBy=foo	-	1	exact	-	contains	Unsupported sortBy value: 'foo'
 config-timeout	dpg-cli --config timeout=900	-	0	contains	Updated config: timeout=900	exact	-
@@ -20,8 +21,8 @@ config-bad-timeout	dpg-cli --config timeout=abc	-	1	exact	-	contains	Invalid tim
 config-editor	dpg-cli --config editor=nano	-	0	contains	Updated config: editor=nano	exact	-
 config-bad-key	dpg-cli --config wat=x	-	1	exact	-	contains	Unknown config key
 config-bad-arg	dpg-cli --config fubar	-	1	exact	-	contains	Config update must use key=value syntax
-config-show-updated	dpg-cli --config	-	0	contains	"timeout": 900	exact	-
-show-profile	dpg-cli --show-profile github-main	-	0	contains	"label": "github-main"	exact	-
+config-show-updated	dpg-cli --config	-	0	contains	\qtimeout\q: 900	exact	-
+show-profile	dpg-cli --show-profile github-main	-	0	contains	\qlabel\q: \qgithub-main\q	exact	-
 edit-missing	dpg-cli --edit foobar	-	1	exact	-	contains	Profile not found: foobar
-config-editor-with-args	dpg-cli --config "editor=vi -f"	-	0	contains	Updated config: editor=vi -f	exact	-
-config-show-editor-with-args	dpg-cli --config	-	0	contains	"editor": "vi -f"	exact	-
+config-editor-with-args	dpg-cli --config \qeditor=vi -f\q	-	0	contains	Updated config: editor=vi -f	exact	-
+config-show-editor-with-args	dpg-cli --config	-	0	contains	\qeditor\q: \qvi -f\q	exact	-


### PR DESCRIPTION
# Normalize TSV quoting and escape handling

## Summary  
Normalize quoting and escape handling in the TSV integration test file to eliminate editor/tool warnings and make the format predictable and contributor-friendly.

## Changes  
- Introduce custom escape sequences:
  - `\q` → `"`
  - `\n` → newline  
- Update integration test harness to unescape values before comparison  
- Apply unescaping to:
  - expected stdout  
  - expected stderr  
  - stdin  
  - command string (for safe argument handling)  
- Replace all literal quotes in TSV with `\q`  
- Fix stdin handling to preserve newline semantics  
- Add test coverage for:
  - quote unescaping  
  - multiline matching  
  - exact multiline output  

## Behavior  
- Test semantics unchanged  
- TSV format is now tool-friendly and consistent  
- Multiline and quoted output can be expressed cleanly  

## Testing  
- All existing integration tests updated and passing  
- Added tests verifying:
  - `\q` correctly maps to `"`  
  - `\n` correctly maps to newline  
  - exact matching works across multiple lines  

## Benefits  
- Eliminates IntelliJ and GitHub TSV parsing issues  
- Enables IntelliJ table editing view for test authoring  
- Improves readability and maintainability of test cases  
- Lays groundwork for future enhancements (e.g. regex, richer assertions)

## Notes  
- Escaping rules are intentionally minimal and explicit  
- This is a test harness improvement; no CLI behavior changes  

---

## 🧓 One-line summary  

Made the tests easier to read, easier to write, and harder to break.