### PR TITLE
DPG-034: Introduce ProfilesRepository and complete CLI migration

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -18,7 +18,7 @@ This is not a general-purpose test framework.
 
 It is a **small, purpose-built DSL** for testing CLI behavior with minimal ceremony and maximum clarity.
 
-> Prefer clarity over cleverness, and explicit behavior over implicit magic.
+> Prefer clarity to cleverness, and explicit behavior over implicit magic.
 
 ---
 
@@ -26,7 +26,7 @@ It is a **small, purpose-built DSL** for testing CLI behavior with minimal cerem
 
 Each test is a single TSV row with the following columns:
 
-| Column            | Description                                  |
+| Column           | Description                                  |
 |------------------|----------------------------------------------|
 | name             | Unique test identifier                       |
 | command          | CLI command to execute                       |
@@ -64,14 +64,21 @@ contains	\qsortBy\q: \qlabel\q
 
 This will be interpreted by the harness as:
 
-```json
-"sortBy": "label"
+```markdown
+..."sortBy": "label"...
 ```
 
 Multiline example:
 
 ```
 exact	line1\nline2
+```
+
+This will be interpreted by the harness as:
+
+```markdown
+line1
+line2
 ```
 
 ---

--- a/integration/README.md
+++ b/integration/README.md
@@ -18,7 +18,7 @@ This is not a general-purpose test framework.
 
 It is a **small, purpose-built DSL** for testing CLI behavior with minimal ceremony and maximum clarity.
 
-> Prefer clarity to cleverness, and explicit behavior over implicit magic.
+> Prefer clarity over cleverness, and explicit behavior over implicit magic.
 
 ---
 
@@ -64,7 +64,7 @@ contains	\qsortBy\q: \qlabel\q
 
 This will be interpreted by the harness as:
 
-```markdown
+```
 ..."sortBy": "label"...
 ```
 
@@ -76,7 +76,7 @@ exact	line1\nline2
 
 This will be interpreted by the harness as:
 
-```markdown
+```
 line1
 line2
 ```

--- a/integration/tests.tsv
+++ b/integration/tests.tsv
@@ -28,7 +28,7 @@ config-show-editor-with-args	dpg-cli --config	-	0	contains	\qeditor\q: \qvi -f\q
 
 show-profile	dpg-cli --show-profile github-main	-	0	contains	\qlabel\q: \qgithub-main\q	exact	-
 
-edit-missing	dpg-cli --edit foobar	-	1	exact	-	contains	Profile not found: foobar
+edit-missing	dpg-cli --edit foobar	-	1	exact	-	contains	Profile not found: 'foobar'
 
 create-reqsym	dpg-cli --new reqsym	-	0	exact	Created profile: 'reqsym'	exact	-
 

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -1,4 +1,3 @@
-import { loadProfileByLabel, saveProfiles, loadAllProfiles } from './profiles-file.js'
 import { createDefaultProfile } from './profile-factory.js'
 import { promptForMasterPassword } from './prompt.js'
 import { generatePassword } from './generate.js'
@@ -9,11 +8,9 @@ import { serializeProfilePretty } from './profile-serialization.js'
 import { formatProfileList } from './list-formatting.js'
 import { loadConfig, saveConfig, parseConfigAssignment, applyConfigUpdate } from "./config-file.js";
 import { readTempFile, writeTempFile, deleteTempFile, openInEditor } from "./editor.js"
-import {
-  diffChangedEditableFields,
-  extractEditableProfileFields,
-  mergeEditableProfileFields, validateEditableProfileFields
-} from "./editable-profile.js";
+import { diffChangedEditableFields, extractEditableProfileFields, mergeEditableProfileFields,
+  validateEditableProfileFields} from "./editable-profile.js";
+import { ProfilesRepository } from './profiles-repository.js'
 /** @typedef {import('./models.js').CliDeps} CliDeps */
 /** @typedef {import('./models.js').CliArgs} CliArgs */
 
@@ -24,9 +21,6 @@ import {
  */
 export async function runCli(args, deps = {}) {
   const {
-    loadProfileByLabel: load = loadProfileByLabel,
-    loadAllProfiles: loadAll = loadAllProfiles,
-    saveProfiles: save = saveProfiles,
     promptForMasterPassword: prompt = promptForMasterPassword,
     generatePassword: generate = generatePassword,
     copyToClipboard: copy = copyToClipboard,
@@ -37,6 +31,7 @@ export async function runCli(args, deps = {}) {
     openInEditor: openEditor = openInEditor,
     loadConfig: loadCfg = loadConfig,
     saveConfig: saveCfg = saveConfig,
+    ProfilesRepositoryClass = ProfilesRepository,
     stdout = process.stdout,
     stderr = process.stderr
   } = deps
@@ -50,14 +45,19 @@ export async function runCli(args, deps = {}) {
     checkForConflicts(args)
 
     if (args.list) {
-      const profiles = await loadAll()
-      const config = await loadCfg()
-      stdout.write(formatProfileList(profiles, config.sortBy) + '\n')
-      return 0
-    }
+      const repo = await ProfilesRepositoryClass.load()
+
+      stdout.write(formatProfileList(repo.list()) + '\n')
+      return 0    }
 
     if (args.bump) {
-      const profile = await load(args.bump)
+      const repo = await ProfilesRepositoryClass.load()
+
+      const profile = repo.get(args.bump)
+      if (!profile) {
+        stderr.write(`Profile '${args.bump}' does not exist\n`)
+        return 1
+      }
 
       const oldCounter = profile.counter
       const newCounter = oldCounter + 1
@@ -85,12 +85,13 @@ export async function runCli(args, deps = {}) {
           updatedAt: now
         }
 
-        const all = await loadAll()
-        const updated = all.map(p =>
-          p.label === profile.label ? updatedProfile : p
-        )
-
-        await save(updated)
+        try {
+          repo.replace(updatedProfile)
+          await repo.persist()
+        } catch (err) {
+          stderr.write(`${err.message}\n`)
+          return 1
+        }
 
         stdout.write(`Counter: ${oldCounter} → ${newCounter} (saved)\n`)
       } else {
@@ -101,22 +102,34 @@ export async function runCli(args, deps = {}) {
     }
 
     if (args.create) {
-      const all = await loadAll()
+      const repo = await ProfilesRepositoryClass.load()
 
-      if (all.some(p => p.label === args.create)) {
-        stderr.write(`Profile already exists: '${args.create}'\n`)
+      if (repo.get(args.create)) {
+        stderr.write(`Profile '${args.create}' already exists\n`)
         return 1
       }
 
       const profile = createDefaultProfile(args.create)
-      await save([...all, profile])
+      try {
+        repo.create(profile)
+        await repo.persist()
+      } catch (err) {
+        stderr.write(`${err.message}\n`)
+        return 1
+      }
 
       stdout.write(`Created profile: '${args.create}'\n`)
       return 0
     }
 
     if (args.editLabel) {
-      const original = await load(args.editLabel)
+      const repo = await ProfilesRepositoryClass.load()
+
+      const original = repo.get(args.editLabel)
+      if (!original) {
+        stderr.write(`Profile not found: '${args.editLabel}'\n`)
+        return 1
+      }
 
       const editable = extractEditableProfileFields(original)
       const content = JSON.stringify(editable, null, 2)
@@ -174,10 +187,8 @@ export async function runCli(args, deps = {}) {
             updatedAt: new Date().toISOString()
         }
 
-        const all = await loadAll()
-        const updated = all.map(p => p.label === original.label ? updatedProfile : p)
-
-        await save(updated)
+        repo.replace(updatedProfile)
+        await repo.persist()
         stdout.write(`Updated profile '${args.editLabel}'\n`)
         return 0
       } finally {
@@ -186,10 +197,11 @@ export async function runCli(args, deps = {}) {
     }
 
     if (args.deleteLabel) {
-      const all = await loadAll()
-      const existing = all.find(p => p.label === args.deleteLabel)
+      const repo = await ProfilesRepositoryClass.load()
 
-      if (!existing) {
+      const profile = repo.get(args.deleteLabel)
+
+      if (!profile) {
         stderr.write(`Profile does not exist: '${args.deleteLabel}'\n`)
         return 1
       }
@@ -203,16 +215,24 @@ export async function runCli(args, deps = {}) {
         return 0
       }
 
-      const remaining = all.filter(p => p.label !== args.deleteLabel)
-      await save(remaining)
+      repo.delete(args.deleteLabel)
+      await repo.persist()
 
       stdout.write(`Deleted profile: '${args.deleteLabel}'\n`)
       return 0
     }
 
     if (args.showProfileLabel) {
-      const profile = await load(args.showProfileLabel)
-      stdout.write(serializeProfilePretty(profile) + '\n')
+      const repo = await ProfilesRepositoryClass.load()
+
+      const profile = repo.get(args.showProfileLabel)
+
+      if (!profile) {
+        stderr.write(`Profile '${args.showProfileLabel}' does not exist\n`)
+        return 1
+      }
+
+      stdout.write(`${serializeProfilePretty(profile)}\n`)
       return 0
     }
 
@@ -232,7 +252,15 @@ export async function runCli(args, deps = {}) {
       return 0
     }
 
-    const profile = await load(args.profileLabel)
+    const repo = await ProfilesRepositoryClass.load()
+
+    const profile = repo.get(args.profileLabel)
+
+    if (!profile) {
+      stderr.write(`Profile not found: '${args.profileLabel}'\n`)
+      return 1
+    }
+
     const masterPassword = await prompt()
     const password = await generate(masterPassword, profile)
 

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -187,8 +187,14 @@ export async function runCli(args, deps = {}) {
             updatedAt: new Date().toISOString()
         }
 
-        repo.replace(updatedProfile)
-        await repo.persist()
+        try {
+          repo.replace(updatedProfile)
+          await repo.persist()
+        } catch (err) {
+          stderr.write(`${err.message}\n`)
+          return 1
+        }
+
         stdout.write(`Updated profile '${args.editLabel}'\n`)
         return 0
       } finally {
@@ -215,8 +221,13 @@ export async function runCli(args, deps = {}) {
         return 0
       }
 
-      repo.delete(args.deleteLabel)
-      await repo.persist()
+      try {
+        repo.delete(args.deleteLabel)
+        await repo.persist()
+      } catch (err) {
+        stderr.write(`${err.message}\n`)
+        return 1
+      }
 
       stdout.write(`Deleted profile: '${args.deleteLabel}'\n`)
       return 0

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -9,11 +9,9 @@ import { serializeProfilePretty } from './profile-serialization.js'
 import { formatProfileList } from './list-formatting.js'
 import { loadConfig, saveConfig, parseConfigAssignment, applyConfigUpdate } from "./config-file.js";
 import { readTempFile, writeTempFile, deleteTempFile, openInEditor } from "./editor.js"
-import {
-  diffChangedEditableFields,
-  extractEditableProfileFields,
-  mergeEditableProfileFields, validateEditableProfileFields
-} from "./editable-profile.js";
+import { diffChangedEditableFields, extractEditableProfileFields, mergeEditableProfileFields,
+  validateEditableProfileFields} from "./editable-profile.js";
+import { ProfilesRepository } from './profiles-repository.js'
 /** @typedef {import('./models.js').CliDeps} CliDeps */
 /** @typedef {import('./models.js').CliArgs} CliArgs */
 
@@ -37,6 +35,7 @@ export async function runCli(args, deps = {}) {
     openInEditor: openEditor = openInEditor,
     loadConfig: loadCfg = loadConfig,
     saveConfig: saveCfg = saveConfig,
+    ProfilesRepositoryClass = ProfilesRepository,
     stdout = process.stdout,
     stderr = process.stderr
   } = deps
@@ -50,11 +49,13 @@ export async function runCli(args, deps = {}) {
     checkForConflicts(args)
 
     if (args.list) {
-      const profiles = await loadAll()
-      const config = await loadCfg()
-      stdout.write(formatProfileList(profiles, config.sortBy) + '\n')
-      return 0
-    }
+      const repo = await ProfilesRepositoryClass.load({
+        loadAllProfiles,
+        saveProfiles
+      })
+
+      stdout.write(formatProfileList(repo.list()) + '\n')
+      return 0    }
 
     if (args.bump) {
       const profile = await load(args.bump)
@@ -211,8 +212,19 @@ export async function runCli(args, deps = {}) {
     }
 
     if (args.showProfileLabel) {
-      const profile = await load(args.showProfileLabel)
-      stdout.write(serializeProfilePretty(profile) + '\n')
+      const repo = await ProfilesRepositoryClass.load({
+        loadAllProfiles,
+        saveProfiles
+      })
+
+      const profile = repo.get(args.showProfileLabel)
+
+      if (!profile) {
+        stderr.write(`Profile '${args.showProfileLabel}' does not exist\n`)
+        return 1
+      }
+
+      stdout.write(`${serializeProfilePretty(profile)}\n`)
       return 0
     }
 
@@ -232,7 +244,18 @@ export async function runCli(args, deps = {}) {
       return 0
     }
 
-    const profile = await load(args.profileLabel)
+    const repo = await ProfilesRepositoryClass.load({
+      loadAllProfiles,
+      saveProfiles
+    })
+
+    const profile = repo.get(args.profileLabel)
+
+    if (!profile) {
+      stderr.write(`Profile not found: '${args.profileLabel}'\n`)
+      return 1
+    }
+
     const masterPassword = await prompt()
     const password = await generate(masterPassword, profile)
 

--- a/src/cli-runner.js
+++ b/src/cli-runner.js
@@ -50,8 +50,8 @@ export async function runCli(args, deps = {}) {
 
     if (args.list) {
       const repo = await ProfilesRepositoryClass.load({
-        loadAllProfiles,
-        saveProfiles
+        loadAllProfiles: loadAll,
+        saveProfiles: save
       })
 
       stdout.write(formatProfileList(repo.list()) + '\n')
@@ -187,10 +187,14 @@ export async function runCli(args, deps = {}) {
     }
 
     if (args.deleteLabel) {
-      const all = await loadAll()
-      const existing = all.find(p => p.label === args.deleteLabel)
+      const repo = await ProfilesRepositoryClass.load({
+        loadAllProfiles: loadAll,
+        saveProfiles: save
+      })
 
-      if (!existing) {
+      const profile = repo.get(args.deleteLabel)
+
+      if (!profile) {
         stderr.write(`Profile does not exist: '${args.deleteLabel}'\n`)
         return 1
       }
@@ -204,8 +208,8 @@ export async function runCli(args, deps = {}) {
         return 0
       }
 
-      const remaining = all.filter(p => p.label !== args.deleteLabel)
-      await save(remaining)
+      repo.delete(args.deleteLabel)
+      await repo.persist()
 
       stdout.write(`Deleted profile: '${args.deleteLabel}'\n`)
       return 0
@@ -213,8 +217,8 @@ export async function runCli(args, deps = {}) {
 
     if (args.showProfileLabel) {
       const repo = await ProfilesRepositoryClass.load({
-        loadAllProfiles,
-        saveProfiles
+        loadAllProfiles: loadAll,
+        saveProfiles: save
       })
 
       const profile = repo.get(args.showProfileLabel)
@@ -245,8 +249,8 @@ export async function runCli(args, deps = {}) {
     }
 
     const repo = await ProfilesRepositoryClass.load({
-      loadAllProfiles,
-      saveProfiles
+      loadAllProfiles: loadAll,
+      saveProfiles: save
     })
 
     const profile = repo.get(args.profileLabel)

--- a/src/models.js
+++ b/src/models.js
@@ -122,7 +122,9 @@
  *     saveProfiles?: (profiles: Profile[]) => Promise<void>
  *   }) => Promise<{
  *     list: () => Profile[],
- *     get: (label: string) => Profile | null
+ *     get: (label: string) => Profile | null,
+ *     delete: (label: string) => void,
+ *     persist: () => Promise<void>
  *   }>
  * }} ProfilesRepositoryFactory
  */

--- a/src/models.js
+++ b/src/models.js
@@ -77,6 +77,7 @@
  *   openInEditor?: (editor: string, filePath: string) => Promise<number>,
  *   loadConfig?: () => Promise<Config>,
  *   saveConfig?: (config: Config) => Promise<void>,
+ *   ProfilesRepositoryClass?: ProfilesRepositoryFactory,
  *   stdout?: { write: (s: string) => void },
  *   stderr?: { write: (s: string) => void }
  * }} CliDeps
@@ -112,6 +113,18 @@
 
 /**
  * @typedef {typeof import('node:child_process').spawn} EditorSpawn
+ */
+
+/**
+ * @typedef {{
+ *   load: (deps?: {
+ *     loadAllProfiles?: () => Promise<Profile[]>,
+ *     saveProfiles?: (profiles: Profile[]) => Promise<void>
+ *   }) => Promise<{
+ *     list: () => Profile[],
+ *     get: (label: string) => Profile | null
+ *   }>
+ * }} ProfilesRepositoryFactory
  */
 
 export {}

--- a/src/models.js
+++ b/src/models.js
@@ -64,9 +64,6 @@
 
 /**
  * @typedef {{
- *   loadProfileByLabel?: (label: string) => Promise<Profile>,
- *   loadAllProfiles?: () => Promise<Profile[]>,
- *   saveProfiles?: (profiles: Profile[]) => Promise<void>,
  *   promptForMasterPassword?: () => Promise<string>,
  *   promptForConfirmation?: (prompt: string) => Promise<string>,
  *   generatePassword?: (master: string, profile: Profile) => Promise<string>,
@@ -77,6 +74,7 @@
  *   openInEditor?: (editor: string, filePath: string) => Promise<number>,
  *   loadConfig?: () => Promise<Config>,
  *   saveConfig?: (config: Config) => Promise<void>,
+ *   ProfilesRepositoryClass?: ProfilesRepositoryFactory,
  *   stdout?: { write: (s: string) => void },
  *   stderr?: { write: (s: string) => void }
  * }} CliDeps
@@ -112,6 +110,22 @@
 
 /**
  * @typedef {typeof import('node:child_process').spawn} EditorSpawn
+ */
+
+/**
+ * @typedef {{
+ *   load: (deps?: {
+ *     loadAllProfiles?: () => Promise<Profile[]>,
+ *     saveProfiles?: (profiles: Profile[]) => Promise<void>
+ *   }) => Promise<{
+ *     list: () => Profile[],
+ *     get: (label: string) => Profile | null,
+ *     delete: (label: string) => void,
+ *     create: (profile: Profile) => void
+ *     replace: (profile: Profile) => void
+ *     persist: () => Promise<void>
+ *   }>
+ * }} ProfilesRepositoryFactory
  */
 
 export {}

--- a/src/profiles-file.js
+++ b/src/profiles-file.js
@@ -21,49 +21,6 @@ export function resolveProfilesPath(options = {}) {
   }
 }
 
-/**
- * @param {unknown} profiles
- * @param {string} label
- * @returns {any}
- */
-export function findProfileByLabel(profiles, label) {
-  if (!Array.isArray(profiles)) {
-    throw new Error('Profiles file must contain a JSON array')
-  }
-
-  const match = profiles.find(profile => profile?.label === label)
-  if (!match) {
-    throw new Error(`Profile not found: ${label}`)
-  }
-
-  return match
-}
-
-/**
- * @param {string} label
- * @param {{ profilesPath?: string }=} options
- * @returns {Promise<any>}
- */
-export async function loadProfileByLabel(label, options = {}) {
-  const profilesPath = options.profilesPath ?? resolveProfilesPath()
-  let text
-
-  try {
-    text = await fs.readFile(profilesPath, 'utf8')
-  } catch (error) {
-    throw new Error(`Profiles file not found: ${profilesPath}`)
-  }
-
-  let parsed
-  try {
-    parsed = JSON.parse(text)
-  } catch (error) {
-    throw new Error(`Profiles file is not valid JSON: ${profilesPath}`)
-  }
-
-  return findProfileByLabel(parsed, label)
-}
-
 export async function loadAllProfiles(options = {}) {
   const profilesPath = options.profilesPath ?? resolveProfilesPath()
 

--- a/src/profiles-repository.js
+++ b/src/profiles-repository.js
@@ -1,0 +1,72 @@
+import { loadAllProfiles, saveProfiles } from './profiles-file.js'
+/** @typedef {import('./models.js').Profile} Profile */
+
+export class ProfilesRepository {
+  /**
+   * @param {Profile[]} profiles
+   * @param {{ saveProfiles?: (profiles: Profile[]) => Promise<void> }} [deps]
+   */
+  constructor(profiles, deps = {}) {
+    this._profiles = [...profiles]
+    this._saveProfiles = deps.saveProfiles ?? saveProfiles
+  }
+
+  /**
+   * @param {{ loadAllProfiles?: () => Promise<Profile[]>, saveProfiles?: (profiles: Profile[]) => Promise<void> }} [deps]
+   * @returns {Promise<ProfilesRepository>}
+   */
+  static async load(deps = {}) {
+    const load = deps.loadAllProfiles ?? loadAllProfiles
+    const save = deps.saveProfiles ?? saveProfiles
+
+    const profiles = await load()
+
+    return new ProfilesRepository(profiles, {
+      saveProfiles: save
+    })
+  }
+
+  /**
+   * @returns {Profile[]}
+   */
+  list() {
+    return [...this._profiles]
+  }
+
+  /**
+   * @param {string} label
+   * @returns {Profile|null}
+   */
+  get(label) {
+    return this._profiles.find(p => p.label === label) ?? null
+  }
+
+  /**
+   * @param {Profile} profile
+   */
+  create(profile) {
+    this._profiles.push(profile)
+  }
+
+  /**
+   * @param {Profile} profile
+   */
+  replace(profile) {
+    const i = this._profiles.findIndex(p => p.label === profile.label)
+    this._profiles[i] = profile
+  }
+
+  /**
+   * @param {string} label
+   */
+  delete(label) {
+    this._profiles = this._profiles.filter(p => p.label !== label)
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  async persist() {
+    await this._saveProfiles(this._profiles)
+  }
+}

--- a/src/profiles-repository.js
+++ b/src/profiles-repository.js
@@ -45,6 +45,10 @@ export class ProfilesRepository {
    * @param {Profile} profile
    */
   create(profile) {
+    if (this.get(profile.label)) {
+      throw new Error(`Profile already exists: '${profile.label}'`)
+    }
+
     this._profiles.push(profile)
   }
 
@@ -53,6 +57,11 @@ export class ProfilesRepository {
    */
   replace(profile) {
     const i = this._profiles.findIndex(p => p.label === profile.label)
+
+    if (i === -1) {
+      throw new Error(`Profile does not exist: '${profile.label}'`)
+    }
+
     this._profiles[i] = profile
   }
 
@@ -60,6 +69,12 @@ export class ProfilesRepository {
    * @param {string} label
    */
   delete(label) {
+    const i = this._profiles.findIndex(p => p.label === label)
+
+    if (i === -1) {
+      throw new Error(`Profile does not exist: '${label}'`)
+    }
+
     this._profiles = this._profiles.filter(p => p.label !== label)
   }
 

--- a/src/profiles-repository.js
+++ b/src/profiles-repository.js
@@ -1,0 +1,68 @@
+import { loadAllProfiles, saveProfiles } from './profiles-file.js'
+/** @typedef {import('./models.js').Profile} Profile */
+
+export class ProfilesRepository {
+  /**
+   * @param {Profile[]} profiles
+   * @param {{ saveProfiles?: (profiles: Profile[]) => Promise<void> }} [deps]
+   */
+  constructor(profiles, deps = {}) {
+    this._profiles = [...profiles]
+    this._saveProfiles = deps.saveProfiles ?? saveProfiles
+  }
+
+  /**
+   * @param {{ loadAllProfiles?: () => Promise<Profile[]>, saveProfiles?: (profiles: Profile[]) => Promise<void> }} [deps]
+   * @returns {Promise<ProfilesRepository>}
+   */
+  static async load(deps = {}) {
+    const load = deps.loadAllProfiles ?? loadAllProfiles
+    const profiles = await load()
+
+    return new ProfilesRepository(profiles, deps)
+  }
+
+  /**
+   * @returns {Profile[]}
+   */
+  list() {
+    return [...this._profiles]
+  }
+
+  /**
+   * @param {string} label
+   * @returns {Profile|null}
+   */
+  get(label) {
+    return this._profiles.find(p => p.label === label) ?? null
+  }
+
+  /**
+   * @param {Profile} profile
+   */
+  create(profile) {
+    this._profiles.push(profile)
+  }
+
+  /**
+   * @param {Profile} profile
+   */
+  replace(profile) {
+    const i = this._profiles.findIndex(p => p.label === profile.label)
+    this._profiles[i] = profile
+  }
+
+  /**
+   * @param {string} label
+   */
+  delete(label) {
+    this._profiles = this._profiles.filter(p => p.label !== label)
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  async persist() {
+    await this._saveProfiles(this._profiles)
+  }
+}

--- a/test/bump.test.js
+++ b/test/bump.test.js
@@ -2,17 +2,19 @@ import { describe, it, expect, vi } from 'vitest'
 import { runCli } from '../src/cli-runner.js'
 import { makeProfile } from './fixtures/profiles.js'
 import { makeCliArgs } from './fixtures/cli.js'
+import {profilesRepositoryClassMock} from "./mocks/profiles-repository.js";
 
 describe('bump command', () => {
   it('bumps counter in memory and generates password', async () => {
     const profile = makeProfile({ label: 'github', counter: 5 })
+    const repoMock = profilesRepositoryClassMock([profile])
 
     const stdout = { write: vi.fn() }
 
     const exitCode = await runCli(
       makeCliArgs({ bump: 'github', show: false, save: false }),
       {
-        loadProfileByLabel: async () => profile,
+        ProfilesRepositoryClass: repoMock,
         generatePassword: async () => 'pw',
         copyToClipboard: async () => {},
         promptForMasterPassword: async () => 'master',
@@ -22,6 +24,8 @@ describe('bump command', () => {
     )
 
     expect(exitCode).toBe(0)
+    expect(repoMock.repo.replace).not.toHaveBeenCalled()
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
 
     const output = stdout.write.mock.calls.map(c => c[0]).join('')
     expect(output).toMatch(/5/)
@@ -30,20 +34,12 @@ describe('bump command', () => {
 
   it('persists counter when --save is used', async () => {
     const profile = makeProfile({ label: 'github', counter: 5 })
-
-    let savedProfiles = null
+    const repoMock = profilesRepositoryClassMock([profile])
 
     const exitCode = await runCli(
       makeCliArgs({ bump: 'github', show: false, save: true }),
       {
-        loadProfileByLabel: async label => {
-          if (label === 'github') return profile
-          throw new Error(`Profile not found: ${label}`)
-        },
-        loadAllProfiles: async () => [profile],
-        saveProfiles: async profiles => {
-          savedProfiles = profiles
-        },
+        ProfilesRepositoryClass: repoMock,
         generatePassword: async () => 'pw',
         copyToClipboard: async () => {},
         promptForMasterPassword: async () => 'master',
@@ -53,8 +49,89 @@ describe('bump command', () => {
     )
 
     expect(exitCode).toBe(0)
-    expect(savedProfiles).not.toBeNull()
-    const result = savedProfiles
-    expect(result[0].counter).toBe(6)
+    expect(repoMock.repo.replace).toHaveBeenCalled()
+    expect(repoMock.repo.persist).toHaveBeenCalled()
+    const updatedProfile = repoMock.repo.replace.mock.calls[0][0]
+
+    expect(updatedProfile.counter).toBe(6)
+  })
+
+  it('does not report saved if save fails', async () => {
+    const profile = makeProfile({ label: 'github', counter: 5 })
+    const repoMock = profilesRepositoryClassMock([profile], {
+      persist: vi.fn(async () => {
+        throw new Error('disk full')
+      })
+    })
+
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ bump: 'github', save: true }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        generatePassword: async () => 'pw',
+        copyToClipboard: async () => {},
+        promptForMasterPassword: async () => 'master',
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(repoMock.repo.replace).toHaveBeenCalled()
+    expect(repoMock.repo.persist).toHaveBeenCalled()
+
+    const output = stdout.write.mock.calls.map(c => c[0]).join('')
+    expect(output).not.toMatch(/\(saved\)/)
+  })
+
+  it('updates updatedAt when saved', async () => {
+    const profile = makeProfile({
+      label: 'github',
+      counter: 5,
+      updatedAt: '2020-01-01T00:00:00.000Z'
+    })
+    const repoMock = profilesRepositoryClassMock([profile])
+
+    const exitCode = await runCli(
+      makeCliArgs({ bump: 'github', save: true }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        generatePassword: async () => 'pw',
+        copyToClipboard: async () => {},
+        promptForMasterPassword: async () => 'master',
+        stdout: { write: () => {} },
+        stderr: { write: () => {} }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+
+    expect(repoMock.repo.replace).toHaveBeenCalled()
+    const updatedProfile = repoMock.repo.replace.mock.calls[0][0]
+
+    expect(updatedProfile.counter).toBe(6)
+    expect(updatedProfile.updatedAt).not.toBe(profile.updatedAt)
+    expect(repoMock.repo.persist).toHaveBeenCalled()
+  })
+
+  it('fails to bump if profile does not exist', async () => {
+    const stderr = { write: vi.fn() }
+    const repoMock = profilesRepositoryClassMock([])
+
+    const exitCode = await runCli(
+      makeCliArgs({ bump: 'nope' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        stderr,
+        stdout: { write: () => {} }
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
+    expect(repoMock.repo.replace).not.toHaveBeenCalled()
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
   })
 })

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -113,18 +113,20 @@ describe('runCli', () => {
 
   it('new profile is visible in list output', async () => {
     const created = createDefaultProfile('github-main', '2026-04-14T12:00:00.000Z')
+    const repoMock = profilesRepositoryClassMock([created])
     const stdout = { write: vi.fn() }
 
     const exitCode = await runCli(
       makeCliArgs({ list: true }),
       {
-        loadAllProfiles: async () => [created],
+        ProfilesRepositoryClass: repoMock,
         stdout,
         stderr: { write: vi.fn() }
       }
     )
 
     expect(exitCode).toBe(0)
+    expect(repoMock.load).toHaveBeenCalled()
     expect(stdout.write).toHaveBeenCalledWith(expect.stringMatching(/github-main/))
   })
 

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -1,22 +1,12 @@
-import { describe, it, expect, vi } from 'vitest'
-import { runCli } from '../src/cli-runner.js'
+import {describe, expect, it, vi} from 'vitest'
+import {runCli} from '../src/cli-runner.js'
 import {DEFAULT_PROFILE, makeProfile} from './fixtures/profiles.js'
-import { makeCliArgs } from './fixtures/cli.js'
-import {createDefaultProfile} from "../src/profile-factory.js";
-import fs from 'node:fs/promises'
-import path from "node:path";
-import {tmpdir} from "node:os";
-import {loadAllProfiles, saveProfiles} from "../src/profiles-file.js";
-import { makeConfig } from './fixtures/config.js'
-import {openInEditor} from "../src/editor.js";
-/** @typedef {import('../src/models.js').Profile} Profile */
-/** @typedef {import('../src/models.js').Config} Config */
-/** @typedef {import('../src/models.js').EditorSpawn} EditorSpawn */
-/** @typedef {import('node:child_process').ChildProcess} ChildProcess */
+import {makeCliArgs} from './fixtures/cli.js'
+import {profilesRepositoryClassMock} from "./mocks/profiles-repository.js";
 
 describe('runCli', () => {
   it('loads profile, prompts for password, generates, copies, and prints success', async () => {
-    const loadProfileByLabel = vi.fn(async () => DEFAULT_PROFILE)
+    const repoMock = profilesRepositoryClassMock([DEFAULT_PROFILE])
     const promptForMasterPassword = vi.fn(async () => 'master')
     const generatePassword = vi.fn(async () => 'generated-secret')
     const copyToClipboard = vi.fn(async () => {})
@@ -26,17 +16,17 @@ describe('runCli', () => {
     const exitCode = await runCli(
       makeCliArgs({ profileLabel: 'github-main', show: false, help: false }),
       {
-        loadProfileByLabel,
         promptForMasterPassword,
         generatePassword,
         copyToClipboard,
+        ProfilesRepositoryClass: repoMock,
         stdout,
         stderr
       }
     )
 
     expect(exitCode).toBe(0)
-    expect(loadProfileByLabel).toHaveBeenCalledWith('github-main')
+    expect(repoMock.load).toHaveBeenCalled()
     expect(promptForMasterPassword).toHaveBeenCalled()
     expect(generatePassword).toHaveBeenCalledWith('master', DEFAULT_PROFILE)
     expect(copyToClipboard).toHaveBeenCalledWith('generated-secret')
@@ -45,11 +35,12 @@ describe('runCli', () => {
 
   it('prints password when --show is used', async () => {
     const stdout = { write: vi.fn() }
+    const repoMock = profilesRepositoryClassMock([DEFAULT_PROFILE])
 
     const exitCode = await runCli(
       makeCliArgs({ profileLabel: 'github-main', show: true, help: false }),
       {
-        loadProfileByLabel: async () => DEFAULT_PROFILE,
+        ProfilesRepositoryClass: repoMock,
         promptForMasterPassword: async () => 'master',
         generatePassword: async () => 'generated-secret',
         copyToClipboard: async () => {},
@@ -59,70 +50,8 @@ describe('runCli', () => {
     )
 
     expect(exitCode).toBe(0)
+    expect(repoMock.load).toHaveBeenCalled()
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('generated-secret'))
-  })
-
-  it('creates a new profile', async () => {
-
-    /** @type Profile[] */
-    let savedProfiles = null
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ create: 'github-main' }),
-      {
-        loadAllProfiles: async () => [],
-        saveProfiles: async profiles => { savedProfiles = profiles },
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-
-    if (!savedProfiles) throw new Error('not saved')
-    expect(savedProfiles).toHaveLength(1)
-    const savedProfile = savedProfiles[0]
-    expect(savedProfile.label).toBe('github-main')
-    expect(savedProfile.service).toBe('github-main')
-    expect(savedProfile.counter).toBe(0)
-    expect(savedProfile.require.length).toBe(4)
-    expect(savedProfile.length).toBe(20)
-    expect(stdout.write).toHaveBeenCalledWith("Created profile: 'github-main'\n")
-  })
-
-  it('fails when creating a duplicate profile', async () => {
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ create: 'github-main' }),
-      {
-        loadAllProfiles: async () => [makeProfile({ label: 'github-main' })],
-        saveProfiles: async () => {},
-        stdout: { write: vi.fn() },
-        stderr
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/already exists/i))
-  })
-
-  it('new profile is visible in list output', async () => {
-    const created = createDefaultProfile('github-main', '2026-04-14T12:00:00.000Z')
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ list: true }),
-      {
-        loadAllProfiles: async () => [created],
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringMatching(/github-main/))
   })
 
   it('prints help and exits 0', async () => {
@@ -142,13 +71,12 @@ describe('runCli', () => {
 
   it('prints error and exits 1 on failure', async () => {
     const stderr = { write: vi.fn() }
+    const repoMock = profilesRepositoryClassMock([DEFAULT_PROFILE])
 
     const exitCode = await runCli(
       makeCliArgs({ profileLabel: 'missing', show: false, help: false }),
       {
-        loadProfileByLabel: async () => {
-          throw new Error('Profile not found: missing')
-        },
+        ProfilesRepositoryClass: repoMock,
         promptForMasterPassword: async () => 'master',
         generatePassword: async () => 'generated-secret',
         copyToClipboard: async () => {},
@@ -158,81 +86,8 @@ describe('runCli', () => {
     )
 
     expect(exitCode).toBe(1)
+    expect(repoMock.load).toHaveBeenCalled()
     expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/profile not found/i))
-  })
-
-  it('does not report saved if save fails', async () => {
-    const profile = makeProfile({ label: 'github', counter: 5 })
-
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ bump: 'github', save: true }),
-      {
-        loadProfileByLabel: async () => profile,
-        loadAllProfiles: async () => [profile],
-        saveProfiles: async () => {
-          throw new Error('disk full')
-        },
-        generatePassword: async () => 'pw',
-        copyToClipboard: async () => {},
-        promptForMasterPassword: async () => 'master',
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(1)
-
-    const output = stdout.write.mock.calls.map(c => c[0]).join('')
-    expect(output).not.toMatch(/\(saved\)/)
-  })
-
-  it('updates updatedAt when saved', async () => {
-    const profile = makeProfile({
-      label: 'github',
-      counter: 5,
-      updatedAt: '2020-01-01T00:00:00.000Z'
-    })
-
-    /** @type Profile[] */
-    let savedProfiles = null
-
-    await runCli(
-      makeCliArgs({ bump: 'github', save: true }),
-      {
-        loadProfileByLabel: async () => profile,
-        loadAllProfiles: async () => [profile],
-        saveProfiles: async p => { savedProfiles = p },
-        generatePassword: async () => 'pw',
-        copyToClipboard: async () => {},
-        promptForMasterPassword: async () => 'master',
-        stdout: { write: () => {} },
-        stderr: { write: () => {} }
-      }
-    )
-
-    if (!savedProfiles) throw new Error('not saved')
-    const savedProfile = savedProfiles[0]
-    expect(savedProfile.updatedAt).not.toBe(profile.updatedAt)
-  })
-
-  it('fails to bump if profile does not exist', async () => {
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ bump: 'nope' }),
-      {
-        loadProfileByLabel: async () => {
-          throw new Error('Profile not found: nope')
-        },
-        stderr,
-        stdout: { write: () => {} }
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/not found/i))
   })
 
   it('fails when no command is specified', async () => {
@@ -252,182 +107,16 @@ describe('runCli', () => {
     )
   })
 
-  it('treats missing profiles file as empty list', async () => {
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ list: true }),
-      {
-        loadAllProfiles: async () => [],
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(stdout.write).toHaveBeenCalledWith('label  counter\n')
-  })
-
-  it('creates a profile when the profiles file does not exist', async () => {
-    const dir = await fs.mkdtemp(path.join(tmpdir(), 'dpg-'))
-    const profilesPath = path.join(dir, 'profiles.json')
-
-    const stdout = { write: vi.fn() }
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ create: 'github-main' }),
-      {
-        loadAllProfiles: () => loadAllProfiles({ profilesPath }),
-        saveProfiles: profiles => saveProfiles(profiles, { profilesPath }),
-        stdout,
-        stderr
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(stdout.write).toHaveBeenCalledWith("Created profile: 'github-main'\n")
-    expect(stderr.write).not.toHaveBeenCalled()
-
-    const saved = JSON.parse(await fs.readFile(profilesPath, 'utf8'))
-    expect(saved).toHaveLength(1)
-    expect(saved[0].label).toBe('github-main')
-    expect(saved[0].counter).toBe(0)
-  })
-
-  it('deletes an existing profile after confirmation', async () => {
-    const profiles = [
-      makeProfile({ label: 'github-main' }),
-      makeProfile({ label: 'gitlab-main', service: 'gitlab.com' })
-    ]
-
-    /** @type Profile[] */
-    let savedProfiles = null
-
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ deleteLabel: 'github-main' }),
-      {
-        loadAllProfiles: async () => profiles,
-        saveProfiles: async p => { savedProfiles = p },
-        promptForConfirmation: async () => 'y',
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(savedProfiles).not.toBeNull()
-
-    if (!savedProfiles) throw new Error('not saved')
-
-    expect(savedProfiles).toHaveLength(1)
-    expect(savedProfiles[0].label).toBe('gitlab-main')
-    expect(stdout.write).toHaveBeenCalledWith("Deleted profile: 'github-main'\n")
-  })
-
-  it('cancels deletion on default response', async () => {
-    const profiles = [makeProfile({ label: 'github-main' })]
-    let saveCalled = false
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ deleteLabel: 'github-main' }),
-      {
-        loadAllProfiles: async () => profiles,
-        saveProfiles: async () => { saveCalled = true },
-        promptForConfirmation: async () => '',
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(saveCalled).toBe(false)
-    expect(stdout.write).toHaveBeenCalledWith('Cancelled\n')
-  })
-
-  it('cancels deletion on non-y response', async () => {
-    const profiles = [makeProfile({ label: 'github-main' })]
-    let saveCalled = false
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ deleteLabel: 'github-main' }),
-      {
-        loadAllProfiles: async () => profiles,
-        saveProfiles: async () => { saveCalled = true },
-        promptForConfirmation: async () => 'n',
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(saveCalled).toBe(false)
-    expect(stdout.write).toHaveBeenCalledWith('Cancelled\n')
-  })
-
-  it('fails when deleting a non-existent profile', async () => {
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ deleteLabel: 'missing' }),
-      {
-        loadAllProfiles: async () => [makeProfile({ label: 'github-main' })],
-        promptForConfirmation: async () => 'y',
-        stdout: { write: vi.fn() },
-        stderr
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
-  })
-
-  it('does not report deletion if save fails after confirmation', async () => {
-    const profiles = [
-      makeProfile({ label: 'github-main' }),
-      makeProfile({ label: 'gitlab-main', service: 'gitlab.com' })
-    ]
-
-    const stdout = { write: vi.fn() }
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ deleteLabel: 'github-main' }),
-      {
-        loadAllProfiles: async () => profiles,
-        saveProfiles: async () => {
-          throw new Error('disk full')
-        },
-        promptForConfirmation: async () => 'y',
-        stdout,
-        stderr
-      }
-    )
-
-    expect(exitCode).toBe(1)
-
-    const out = stdout.write.mock.calls.map(c => c[0]).join('')
-    expect(out).not.toMatch(/Deleted profile/i)
-
-    expect(stderr.write).toHaveBeenCalledWith(
-      expect.stringMatching(/disk full/i)
-    )
-  })
-
   it('shows an existing profile as pretty-printed JSON', async () => {
-    const profile = makeProfile({ label: 'github-main', service: 'github.com' })
-    const stdout = { write: vi.fn() }
+    const profile = makeProfile({label: 'github-main', service: 'github.com'})
+    const stdout = {write: vi.fn()}
 
     const exitCode = await runCli(
-      makeCliArgs({ showProfileLabel: 'github-main' }),
+      makeCliArgs({showProfileLabel: 'github-main'}),
       {
-        loadProfileByLabel: async () => profile,
+        ProfilesRepositoryClass: profilesRepositoryClassMock([profile]),
         stdout,
-        stderr: { write: vi.fn() }
+        stderr: {write: vi.fn()}
       }
     )
 
@@ -442,19 +131,19 @@ describe('runCli', () => {
   })
 
   it('fails when --show-profile target does not exist', async () => {
-    const stderr = { write: vi.fn() }
+    const stderr = {write: vi.fn()}
+    const repoMock = profilesRepositoryClassMock([])
 
     const exitCode = await runCli(
-      makeCliArgs({ showProfileLabel: 'nope' }),
+      makeCliArgs({showProfileLabel: 'nope'}),
       {
-        loadProfileByLabel: async () => {
-          throw new Error("Profile 'nope' does not exist")
-        },
-        stdout: { write: vi.fn() },
+        ProfilesRepositoryClass: repoMock,
+        stdout: {write: vi.fn()},
         stderr
       }
     )
 
+    expect(repoMock.load).toHaveBeenCalled()
     expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
     expect(exitCode).toBe(1)
   })
@@ -533,670 +222,5 @@ describe('runCli', () => {
 
     expect(exitCode).toBe(1)
     expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/conflicting commands/i))
-  })
-
-  it('shows current config as pretty JSON', async () => {
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ configPresent: true, configArg: null }),
-      {
-        loadConfig: async () => makeConfig({ timeout: 900 }),
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-
-    const output = stdout.write.mock.calls.map(c => c[0]).join('')
-    const parsed = JSON.parse(output)
-
-    expect(parsed).toEqual({
-      timeout: 900,
-      sortBy: 'label',
-      editor: ''
-    })
-  })
-
-  it('updates timeout config and persists it', async () => {
-    /** @type {import('../src/models.js').Config | null} */
-    let savedConfig = null
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ configPresent: true, configArg: 'timeout=900' }),
-      {
-        loadConfig: async () => makeConfig(),
-        saveConfig: async config => { savedConfig = config },
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(savedConfig).toEqual({
-      timeout: 900,
-      sortBy: 'label',
-      editor: ''
-    })
-    expect(stdout.write).toHaveBeenCalledWith('Updated config: timeout=900\n')
-  })
-
-  it('updates sortBy config and persists it', async () => {
-    /** @type {import('../src/models.js').Config | null} */
-    let savedConfig = null
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ configPresent: true, configArg: 'sortBy=label' }),
-      {
-        loadConfig: async () => makeConfig(),
-        saveConfig: async config => { savedConfig = config },
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(savedConfig).toEqual({
-      timeout: 0,
-      sortBy: 'label',
-      editor: ''
-    })
-    expect(stdout.write).toHaveBeenCalledWith('Updated config: sortBy=label\n')
-  })
-
-  it('fails for unknown config key', async () => {
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ configPresent: true, configArg: 'wat=x' }),
-      {
-        loadConfig: async () => makeConfig(),
-        saveConfig: async () => {},
-        stdout: { write: vi.fn() },
-        stderr
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/unknown config key/i))
-  })
-
-  it('fails for invalid timeout', async () => {
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ configPresent: true, configArg: 'timeout=abc' }),
-      {
-        loadConfig: async () => makeConfig(),
-        saveConfig: async () => {},
-        stdout: { write: vi.fn() },
-        stderr
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/invalid timeout/i))
-  })
-
-  it('updates a profile after valid edit and confirmation', async () => {
-    const original = makeProfile({
-      label: 'github-main',
-      service: 'github.com',
-      account: 'peter@example.com',
-      counter: 4,
-      length: 20,
-      require: ['lower', 'upper', 'digit', 'symbol'],
-      symbolSet: '@!#'
-    })
-
-    /** @type {Profile[] | null} */
-    let savedProfiles = null
-
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        saveProfiles: async profiles => { savedProfiles = profiles },
-        writeTempFile: async () => '/tmp/github-main_1776883800.json',
-        openInEditor: async () => 0,
-        readTempFile: async () => JSON.stringify({
-          service: 'github-enterprise.example.com',
-          account: 'peter@example.com',
-          counter: 4,
-          length: 20,
-          require: ['lower', 'upper', 'digit', 'symbol'],
-          symbolSet: '@!#'
-        }, null, 2),
-        deleteTempFile: async () => {},
-        promptForConfirmation: async () => 'y',
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(savedProfiles).not.toBeNull()
-    if (!savedProfiles) throw new Error('not saved')
-
-    const updated = savedProfiles[0]
-    expect(updated.createdAt).toBe(original.createdAt)
-    expect(updated.updatedAt).not.toBe(original.updatedAt)
-    expect(updated.service).toBe('github-enterprise.example.com')
-
-    const output = stdout.write.mock.calls.map(c => c[0]).join('')
-    expect(output).toMatch(/changed fields: service/i)
-    expect(output).toMatch(/will affect the generated password/i)
-    expect(output).toMatch(/Updated profile 'github-main'/)
-  })
-
-  it('prints no changes made when edited content is unchanged', async () => {
-    const original = makeProfile({
-      label: 'github-main'
-    })
-
-    let saveCalled = false
-    let confirmCalled = false
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        saveProfiles: async () => { saveCalled = true },
-        writeTempFile: async () => '/tmp/github-main_1776883800.json',
-        openInEditor: async () => 0,
-        readTempFile: async () => JSON.stringify({
-          service: original.service,
-          account: original.account,
-          counter: original.counter,
-          length: original.length,
-          require: original.require,
-          symbolSet: original.symbolSet
-        }, null, 2),
-        deleteTempFile: async () => {},
-        promptForConfirmation: async () => {
-          confirmCalled = true
-          return 'y'
-        },
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(saveCalled).toBe(false)
-    expect(confirmCalled).toBe(false)
-    expect(stdout.write).toHaveBeenCalledWith('No changes made\n')
-  })
-
-  it('fails and does not persist on invalid JSON', async () => {
-    const original = makeProfile({
-      label: 'github-main'
-    })
-
-    let saveCalled = false
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        saveProfiles: async () => { saveCalled = true },
-        writeTempFile: async () => '/tmp/github-main_1776883800.json',
-        openInEditor: async () => 0,
-        readTempFile: async () => '{ invalid json',
-        deleteTempFile: async () => {},
-        promptForConfirmation: async () => 'y',
-        stdout: { write: vi.fn() },
-        stderr
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(saveCalled).toBe(false)
-    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/invalid json/i))
-  })
-
-  it('fails and does not persist on validation failure', async () => {
-    const original = makeProfile({
-      label: 'github-main'
-    })
-
-    let saveCalled = false
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        saveProfiles: async () => { saveCalled = true },
-        writeTempFile: async () => '/tmp/github-main_1776883800.json',
-        openInEditor: async () => 0,
-        readTempFile: async () => JSON.stringify({
-          service: 'github.com',
-          account: 'peter@example.com',
-          counter: 4,
-          length: -1,
-          require: ['lower', 'upper'],
-          symbolSet: '@!#'
-        }, null, 2),
-        deleteTempFile: async () => {},
-        promptForConfirmation: async () => 'y',
-        stdout: { write: vi.fn() },
-        stderr
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(saveCalled).toBe(false)
-    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/length/i))
-  })
-
-  it('fails for non-existent profile', async () => {
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ editLabel: 'missing' }),
-      {
-        loadProfileByLabel: async () => {
-          throw new Error("Profile 'missing' does not exist")
-        },
-        stdout: { write: vi.fn() },
-        stderr
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
-  })
-
-  it('does not persist if editor exits non-zero', async () => {
-    const original = makeProfile({
-      label: 'github-main'
-    })
-
-    let saveCalled = false
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        saveProfiles: async () => { saveCalled = true },
-        writeTempFile: async () => '/tmp/github-main_1776883800.json',
-        openInEditor: async () => 1,
-        deleteTempFile: async () => {},
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(saveCalled).toBe(false)
-
-    const output = stdout.write.mock.calls.map(c => c[0]).join('')
-    expect(output).not.toMatch(/Updated profile/i)
-  })
-
-  it('does not persist when confirmation is declined', async () => {
-    const original = makeProfile({
-      label: 'github-main',
-      service: 'github.com'
-    })
-
-    let saveCalled = false
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        saveProfiles: async () => { saveCalled = true },
-        writeTempFile: async () => '/tmp/github-main_1776883800.json',
-        openInEditor: async () => 0,
-        readTempFile: async () => JSON.stringify({
-          service: 'gitlab.com',
-          account: original.account,
-          counter: original.counter,
-          length: original.length,
-          require: original.require,
-          symbolSet: original.symbolSet
-        }, null, 2),
-        deleteTempFile: async () => {},
-        promptForConfirmation: async () => 'n',
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(saveCalled).toBe(false)
-
-    const output = stdout.write.mock.calls.map(c => c[0]).join('')
-    expect(output).toMatch(/changed fields: service/i)
-    expect(output).toMatch(/No changes saved/i)
-  })
-
-  it('uses editor from config when set', async () => {
-    const original = makeProfile({ label: 'github-main' })
-
-    let usedEditor = null
-
-    await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        loadConfig: async () => ({ editor: 'emacs' }),
-
-        writeTempFile: async () => '/tmp/file.json',
-        openInEditor: async (editor) => {
-          usedEditor = editor
-          return 1 // force early exit
-        },
-        deleteTempFile: async () => {},
-
-        stdout: { write: vi.fn() },
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(usedEditor).toBe('emacs')
-  })
-
-  it('uses $EDITOR when config editor is not set', async () => {
-    const original = makeProfile({ label: 'github-main' })
-
-    let usedEditor = null
-
-    const prev = process.env.EDITOR
-    process.env.EDITOR = 'nano'
-
-    try {
-      await runCli(
-        makeCliArgs({ editLabel: 'github-main' }),
-        {
-          loadProfileByLabel: async () => original,
-          loadAllProfiles: async () => [original],
-          loadConfig: async () => ({}),
-
-          writeTempFile: async () => '/tmp/file.json',
-          openInEditor: async (editor) => {
-            usedEditor = editor
-            return 1
-          },
-          deleteTempFile: async () => {},
-
-          stdout: { write: vi.fn() },
-          stderr: { write: vi.fn() }
-        }
-      )
-    } finally {
-      process.env.EDITOR = prev
-    }
-
-    expect(usedEditor).toBe('nano')
-  })
-
-  it('falls back to default editor when config and $EDITOR are not set', async () => {
-    const original = makeProfile({ label: 'github-main' })
-
-    let usedEditor = null
-
-    const prev = process.env.EDITOR
-    delete process.env.EDITOR
-
-    try {
-      await runCli(
-        makeCliArgs({ editLabel: 'github-main' }),
-        {
-          loadProfileByLabel: async () => original,
-          loadAllProfiles: async () => [original],
-          loadConfig: async () => ({}),
-
-          writeTempFile: async () => '/tmp/file.json',
-          openInEditor: async (editor) => {
-            usedEditor = editor
-            return 1
-          },
-          deleteTempFile: async () => {},
-
-          stdout: { write: vi.fn() },
-          stderr: { write: vi.fn() }
-        }
-      )
-    } finally {
-      process.env.EDITOR = prev
-    }
-
-    expect(usedEditor).toBe('vi')
-  })
-
-  it('cleans up the temp file after a successful edit', async () => {
-    const original = makeProfile({
-      label: 'github-main',
-      service: 'github.com'
-    })
-
-    let deletedPath = null
-
-    const exitCode = await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        loadConfig: async () => makeConfig({ editor: 'vi' }),
-        saveProfiles: async () => {},
-        writeTempFile: async () => '/tmp/github-main_1776883800.json',
-        openInEditor: async () => 0,
-        readTempFile: async () => JSON.stringify({
-          service: 'gitlab.com',
-          account: original.account,
-          counter: original.counter,
-          length: original.length,
-          require: original.require,
-          symbolSet: original.symbolSet
-        }, null, 2),
-        deleteTempFile: async (filePath) => {
-          deletedPath = filePath
-        },
-        promptForConfirmation: async () => 'y',
-        stdout: { write: vi.fn() },
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(deletedPath).toBe('/tmp/github-main_1776883800.json')
-  })
-
-  it('cleans up the temp file when edited JSON is invalid', async () => {
-    const original = makeProfile({ label: 'github-main' })
-
-    let deletedPath = null
-
-    const exitCode = await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        loadConfig: async () => makeConfig({ editor: 'vi' }),
-        saveProfiles: async () => {},
-        writeTempFile: async () => '/tmp/github-main_1776883800.json',
-        openInEditor: async () => 0,
-        readTempFile: async () => '{ invalid json',
-        deleteTempFile: async (filePath) => {
-          deletedPath = filePath
-        },
-        promptForConfirmation: async () => 'y',
-        stdout: { write: vi.fn() },
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(deletedPath).toBe('/tmp/github-main_1776883800.json')
-  })
-
-  it('fails and does not persist when require contains unknown values', async () => {
-    const original = makeProfile({ label: 'github-main' })
-
-    let saveCalled = false
-    const stderr = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        loadConfig: async () => makeConfig({ editor: 'vi' }),
-        saveProfiles: async () => { saveCalled = true },
-        writeTempFile: async () => '/tmp/file.json',
-        openInEditor: async () => 0,
-        readTempFile: async () => JSON.stringify({
-          service: 'github.com',
-          account: original.account,
-          counter: original.counter,
-          length: original.length,
-          require: ['runes', 'upper'],
-          symbolSet: original.symbolSet
-        }, null, 2),
-        deleteTempFile: async () => {},
-        promptForConfirmation: async () => 'y',
-        stdout: { write: vi.fn() },
-        stderr
-      }
-    )
-
-    expect(exitCode).toBe(1)
-    expect(saveCalled).toBe(false)
-    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/Unknown character class/i))
-  })
-
-  it('updates editor config and persists it', async () => {
-    let savedConfig = null
-    const stdout = { write: vi.fn() }
-
-    const exitCode = await runCli(
-      makeCliArgs({ configPresent: true, configArg: 'editor=nano' }),
-      {
-        loadConfig: async () => makeConfig(),
-        saveConfig: async config => { savedConfig = config },
-        stdout,
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(exitCode).toBe(0)
-    expect(savedConfig).toEqual({
-      timeout: 0,
-      sortBy: 'label',
-      editor: 'nano'
-    })
-    expect(stdout.write).toHaveBeenCalledWith('Updated config: editor=nano\n')
-  })
-
-  it('uses editor command with arguments from config', async () => {
-    const original = makeProfile({ label: 'github-main' })
-    let usedEditor = null
-
-    await runCli(
-      makeCliArgs({ editLabel: 'github-main' }),
-      {
-        loadProfileByLabel: async () => original,
-        loadAllProfiles: async () => [original],
-        loadConfig: async () => makeConfig({ editor: 'code --wait' }),
-        writeTempFile: async () => '/tmp/file.json',
-        openInEditor: async (editor) => {
-          usedEditor = editor
-          return 1
-        },
-        deleteTempFile: async () => {},
-        stdout: { write: vi.fn() },
-        stderr: { write: vi.fn() }
-      }
-    )
-
-    expect(usedEditor).toBe('code --wait')
-  })
-
-  it('splits editor command and appends file path', async () => {
-    let spawnedCommand = null
-    let spawnedArgs = null
-
-    const fakeSpawn =
-      /** @type {EditorSpawn} */ (
-      /** @type {unknown} */ (
-        /**
-         * @param {string} command
-         * @param {readonly string[]} args
-         * @param {object=} _options
-         * @returns {ChildProcess}
-         */
-          (command, args, _options) => {
-          spawnedCommand = command
-          spawnedArgs = [...args]
-
-          return /** @type {ChildProcess} */ ({
-            on: (
-              /** @type {'error' | 'close'} */ event,
-              /** @type {(value: any) => void} */ handler
-            ) => {
-              if (event === 'close') handler(0)
-            }
-          })
-        }
-      )
-    )
-
-    await openInEditor('code --wait', '/tmp/file.json', fakeSpawn)
-
-    expect(spawnedCommand).toBe('code')
-    expect(spawnedArgs).toEqual(['--wait', '/tmp/file.json'])
-  })
-
-  it('supports quoted editor paths', async () => {
-    let spawnedCommand = null
-    let spawnedArgs = null
-
-    const fakeSpawn =
-      /** @type {EditorSpawn} */ (
-      /** @type {unknown} */ (
-        /**
-         * @param {string} command
-         * @param {readonly string[]} args
-         * @param {object=} _options
-         * @returns {ChildProcess}
-         */
-          (command, args, _options) => {
-          spawnedCommand = command
-          spawnedArgs = [...args]
-
-          return /** @type {ChildProcess} */ ({
-            on: (
-              /** @type {'error' | 'close'} */ event,
-              /** @type {(value: any) => void} */ handler
-            ) => {
-              if (event === 'close') handler(0)
-            }
-          })
-        }
-      )
-    )
-
-    await openInEditor('"C:\\Program Files\\Editor\\editor.exe" --wait', 'C:\\tmp\\file.json', fakeSpawn)
-    expect(spawnedCommand).toBe('C:\\Program Files\\Editor\\editor.exe')
-    expect(spawnedArgs).toEqual(['--wait', 'C:\\tmp\\file.json'])
   })
 })

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -9,6 +9,7 @@ import {tmpdir} from "node:os";
 import {loadAllProfiles, saveProfiles} from "../src/profiles-file.js";
 import { makeConfig } from './fixtures/config.js'
 import {openInEditor} from "../src/editor.js";
+import {profilesRepositoryClassMock} from "./mocks/profiles-repository.js";
 /** @typedef {import('../src/models.js').Profile} Profile */
 /** @typedef {import('../src/models.js').Config} Config */
 /** @typedef {import('../src/models.js').EditorSpawn} EditorSpawn */
@@ -16,7 +17,7 @@ import {openInEditor} from "../src/editor.js";
 
 describe('runCli', () => {
   it('loads profile, prompts for password, generates, copies, and prints success', async () => {
-    const loadProfileByLabel = vi.fn(async () => DEFAULT_PROFILE)
+    const repoMock = profilesRepositoryClassMock([DEFAULT_PROFILE])
     const promptForMasterPassword = vi.fn(async () => 'master')
     const generatePassword = vi.fn(async () => 'generated-secret')
     const copyToClipboard = vi.fn(async () => {})
@@ -26,17 +27,17 @@ describe('runCli', () => {
     const exitCode = await runCli(
       makeCliArgs({ profileLabel: 'github-main', show: false, help: false }),
       {
-        loadProfileByLabel,
         promptForMasterPassword,
         generatePassword,
         copyToClipboard,
+        ProfilesRepositoryClass: repoMock,
         stdout,
         stderr
       }
     )
 
     expect(exitCode).toBe(0)
-    expect(loadProfileByLabel).toHaveBeenCalledWith('github-main')
+    expect(repoMock.load).toHaveBeenCalled()
     expect(promptForMasterPassword).toHaveBeenCalled()
     expect(generatePassword).toHaveBeenCalledWith('master', DEFAULT_PROFILE)
     expect(copyToClipboard).toHaveBeenCalledWith('generated-secret')
@@ -45,11 +46,12 @@ describe('runCli', () => {
 
   it('prints password when --show is used', async () => {
     const stdout = { write: vi.fn() }
+    const repoMock = profilesRepositoryClassMock([DEFAULT_PROFILE])
 
     const exitCode = await runCli(
       makeCliArgs({ profileLabel: 'github-main', show: true, help: false }),
       {
-        loadProfileByLabel: async () => DEFAULT_PROFILE,
+        ProfilesRepositoryClass: repoMock,
         promptForMasterPassword: async () => 'master',
         generatePassword: async () => 'generated-secret',
         copyToClipboard: async () => {},
@@ -59,6 +61,7 @@ describe('runCli', () => {
     )
 
     expect(exitCode).toBe(0)
+    expect(repoMock.load).toHaveBeenCalled()
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('generated-secret'))
   })
 
@@ -142,13 +145,12 @@ describe('runCli', () => {
 
   it('prints error and exits 1 on failure', async () => {
     const stderr = { write: vi.fn() }
+    const repoMock = profilesRepositoryClassMock([DEFAULT_PROFILE])
 
     const exitCode = await runCli(
       makeCliArgs({ profileLabel: 'missing', show: false, help: false }),
       {
-        loadProfileByLabel: async () => {
-          throw new Error('Profile not found: missing')
-        },
+        ProfilesRepositoryClass: repoMock,
         promptForMasterPassword: async () => 'master',
         generatePassword: async () => 'generated-secret',
         copyToClipboard: async () => {},
@@ -158,6 +160,7 @@ describe('runCli', () => {
     )
 
     expect(exitCode).toBe(1)
+    expect(repoMock.load).toHaveBeenCalled()
     expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/profile not found/i))
   })
 
@@ -258,7 +261,7 @@ describe('runCli', () => {
     const exitCode = await runCli(
       makeCliArgs({ list: true }),
       {
-        loadAllProfiles: async () => [],
+        ProfilesRepositoryClass: profilesRepositoryClassMock([]),
         stdout,
         stderr: { write: vi.fn() }
       }
@@ -425,7 +428,7 @@ describe('runCli', () => {
     const exitCode = await runCli(
       makeCliArgs({ showProfileLabel: 'github-main' }),
       {
-        loadProfileByLabel: async () => profile,
+        ProfilesRepositoryClass: profilesRepositoryClassMock([profile]),
         stdout,
         stderr: { write: vi.fn() }
       }
@@ -443,18 +446,18 @@ describe('runCli', () => {
 
   it('fails when --show-profile target does not exist', async () => {
     const stderr = { write: vi.fn() }
+    const repoMock = profilesRepositoryClassMock([])
 
     const exitCode = await runCli(
       makeCliArgs({ showProfileLabel: 'nope' }),
       {
-        loadProfileByLabel: async () => {
-          throw new Error("Profile 'nope' does not exist")
-        },
+        ProfilesRepositoryClass: repoMock,
         stdout: { write: vi.fn() },
         stderr
       }
     )
 
+    expect(repoMock.load).toHaveBeenCalled()
     expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
     expect(exitCode).toBe(1)
   })

--- a/test/cli-flow.test.js
+++ b/test/cli-flow.test.js
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi } from 'vitest'
 import { runCli } from '../src/cli-runner.js'
-import {DEFAULT_PROFILE, makeProfile} from './fixtures/profiles.js'
+import { DEFAULT_PROFILE, makeProfile } from './fixtures/profiles.js'
 import { makeCliArgs } from './fixtures/cli.js'
-import {createDefaultProfile} from "../src/profile-factory.js";
+import { createDefaultProfile } from "../src/profile-factory.js";
 import fs from 'node:fs/promises'
 import path from "node:path";
-import {tmpdir} from "node:os";
-import {loadAllProfiles, saveProfiles} from "../src/profiles-file.js";
+import { tmpdir } from "node:os";
+import { loadAllProfiles, saveProfiles } from "../src/profiles-file.js";
 import { makeConfig } from './fixtures/config.js'
-import {openInEditor} from "../src/editor.js";
-import {profilesRepositoryClassMock} from "./mocks/profiles-repository.js";
+import { openInEditor } from "../src/editor.js";
+import { profilesRepositoryClassMock } from "./mocks/profiles-repository.js";
 /** @typedef {import('../src/models.js').Profile} Profile */
 /** @typedef {import('../src/models.js').Config} Config */
 /** @typedef {import('../src/models.js').EditorSpawn} EditorSpawn */
@@ -305,17 +305,14 @@ describe('runCli', () => {
       makeProfile({ label: 'github-main' }),
       makeProfile({ label: 'gitlab-main', service: 'gitlab.com' })
     ]
-
-    /** @type Profile[] */
-    let savedProfiles = null
+    const repoMock = profilesRepositoryClassMock(profiles)
 
     const stdout = { write: vi.fn() }
 
     const exitCode = await runCli(
       makeCliArgs({ deleteLabel: 'github-main' }),
       {
-        loadAllProfiles: async () => profiles,
-        saveProfiles: async p => { savedProfiles = p },
+        ProfilesRepositoryClass: repoMock,
         promptForConfirmation: async () => 'y',
         stdout,
         stderr: { write: vi.fn() }
@@ -323,25 +320,22 @@ describe('runCli', () => {
     )
 
     expect(exitCode).toBe(0)
-    expect(savedProfiles).not.toBeNull()
-
-    if (!savedProfiles) throw new Error('not saved')
-
-    expect(savedProfiles).toHaveLength(1)
-    expect(savedProfiles[0].label).toBe('gitlab-main')
+    expect(repoMock.repo.delete).toHaveBeenCalledWith('github-main')
+    expect(repoMock.repo.persist).toHaveBeenCalled()
+    expect(repoMock.repo.list()).toHaveLength(1)
+    expect(repoMock.repo.list()[0].label).toBe('gitlab-main')
     expect(stdout.write).toHaveBeenCalledWith("Deleted profile: 'github-main'\n")
   })
 
   it('cancels deletion on default response', async () => {
     const profiles = [makeProfile({ label: 'github-main' })]
-    let saveCalled = false
+    const repoMock = profilesRepositoryClassMock(profiles)
     const stdout = { write: vi.fn() }
 
     const exitCode = await runCli(
       makeCliArgs({ deleteLabel: 'github-main' }),
       {
-        loadAllProfiles: async () => profiles,
-        saveProfiles: async () => { saveCalled = true },
+        ProfilesRepositoryClass: repoMock,
         promptForConfirmation: async () => '',
         stdout,
         stderr: { write: vi.fn() }
@@ -349,20 +343,20 @@ describe('runCli', () => {
     )
 
     expect(exitCode).toBe(0)
-    expect(saveCalled).toBe(false)
+    expect(repoMock.repo.list()).toHaveLength(1)
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
     expect(stdout.write).toHaveBeenCalledWith('Cancelled\n')
   })
 
   it('cancels deletion on non-y response', async () => {
     const profiles = [makeProfile({ label: 'github-main' })]
-    let saveCalled = false
+    const repoMock = profilesRepositoryClassMock(profiles)
     const stdout = { write: vi.fn() }
 
     const exitCode = await runCli(
       makeCliArgs({ deleteLabel: 'github-main' }),
       {
-        loadAllProfiles: async () => profiles,
-        saveProfiles: async () => { saveCalled = true },
+        ProfilesRepositoryClass: repoMock,
         promptForConfirmation: async () => 'n',
         stdout,
         stderr: { write: vi.fn() }
@@ -370,17 +364,20 @@ describe('runCli', () => {
     )
 
     expect(exitCode).toBe(0)
-    expect(saveCalled).toBe(false)
+    expect(repoMock.repo.list()).toHaveLength(1)
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
     expect(stdout.write).toHaveBeenCalledWith('Cancelled\n')
   })
 
   it('fails when deleting a non-existent profile', async () => {
+    const profiles = [makeProfile({ label: 'github-main' })]
+    const repoMock = profilesRepositoryClassMock(profiles)
     const stderr = { write: vi.fn() }
 
     const exitCode = await runCli(
       makeCliArgs({ deleteLabel: 'missing' }),
       {
-        loadAllProfiles: async () => [makeProfile({ label: 'github-main' })],
+        ProfilesRepositoryClass: repoMock,
         promptForConfirmation: async () => 'y',
         stdout: { write: vi.fn() },
         stderr
@@ -388,25 +385,29 @@ describe('runCli', () => {
     )
 
     expect(exitCode).toBe(1)
+    expect(repoMock.repo.list()).toHaveLength(1)
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
     expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
   })
 
   it('does not report deletion if save fails after confirmation', async () => {
     const profiles = [
-      makeProfile({ label: 'github-main' }),
-      makeProfile({ label: 'gitlab-main', service: 'gitlab.com' })
+      makeProfile({label: 'github-main'}),
+      makeProfile({label: 'gitlab-main', service: 'gitlab.com'})
     ]
+    const repoMock = profilesRepositoryClassMock(profiles, {
+      persist: vi.fn(async () => {
+        throw new Error('disk full')
+      })
+    })
 
-    const stdout = { write: vi.fn() }
-    const stderr = { write: vi.fn() }
+    const stdout = {write: vi.fn()}
+    const stderr = {write: vi.fn()}
 
     const exitCode = await runCli(
-      makeCliArgs({ deleteLabel: 'github-main' }),
+      makeCliArgs({deleteLabel: 'github-main'}),
       {
-        loadAllProfiles: async () => profiles,
-        saveProfiles: async () => {
-          throw new Error('disk full')
-        },
+        ProfilesRepositoryClass: repoMock,
         promptForConfirmation: async () => 'y',
         stdout,
         stderr
@@ -414,25 +415,22 @@ describe('runCli', () => {
     )
 
     expect(exitCode).toBe(1)
-
-    const out = stdout.write.mock.calls.map(c => c[0]).join('')
-    expect(out).not.toMatch(/Deleted profile/i)
-
-    expect(stderr.write).toHaveBeenCalledWith(
-      expect.stringMatching(/disk full/i)
-    )
+    expect(repoMock.repo.delete).toHaveBeenCalled()
+    expect(repoMock.repo.persist).toHaveBeenCalled()
+    expect(stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('Deleted profile'))
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/disk full/i))
   })
 
   it('shows an existing profile as pretty-printed JSON', async () => {
-    const profile = makeProfile({ label: 'github-main', service: 'github.com' })
-    const stdout = { write: vi.fn() }
+    const profile = makeProfile({label: 'github-main', service: 'github.com'})
+    const stdout = {write: vi.fn()}
 
     const exitCode = await runCli(
-      makeCliArgs({ showProfileLabel: 'github-main' }),
+      makeCliArgs({showProfileLabel: 'github-main'}),
       {
         ProfilesRepositoryClass: profilesRepositoryClassMock([profile]),
         stdout,
-        stderr: { write: vi.fn() }
+        stderr: {write: vi.fn()}
       }
     )
 
@@ -447,14 +445,14 @@ describe('runCli', () => {
   })
 
   it('fails when --show-profile target does not exist', async () => {
-    const stderr = { write: vi.fn() }
+    const stderr = {write: vi.fn()}
     const repoMock = profilesRepositoryClassMock([])
 
     const exitCode = await runCli(
-      makeCliArgs({ showProfileLabel: 'nope' }),
+      makeCliArgs({showProfileLabel: 'nope'}),
       {
         ProfilesRepositoryClass: repoMock,
-        stdout: { write: vi.fn() },
+        stdout: {write: vi.fn()},
         stderr
       }
     )

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,137 @@
+import {describe, it, expect, vi} from "vitest";
+import {makeConfig} from "./fixtures/config.js";
+import {makeCliArgs} from "./fixtures/cli.js";
+import {runCli} from "../src/cli-runner.js";
+/** @typedef {import('../src/models.js').Config} Config */
+/** @typedef {import('../src/models.js').Profile} Profile */
+
+describe('list command', () => {
+  it('shows current config as pretty JSON', async () => {
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: null }),
+      {
+        loadConfig: async () => makeConfig({ timeout: 900 }),
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+
+    const output = stdout.write.mock.calls.map(c => c[0]).join('')
+    const parsed = JSON.parse(output)
+
+    expect(parsed).toEqual({
+      timeout: 900,
+      sortBy: 'label',
+      editor: ''
+    })
+  })
+
+  it('updates timeout config and persists it', async () => {
+    /** @type {import('../src/models.js').Config | null} */
+    let savedConfig = null
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: 'timeout=900' }),
+      {
+        loadConfig: async () => makeConfig(),
+        saveConfig: async config => { savedConfig = config },
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(savedConfig).toEqual({
+      timeout: 900,
+      sortBy: 'label',
+      editor: ''
+    })
+    expect(stdout.write).toHaveBeenCalledWith('Updated config: timeout=900\n')
+  })
+
+  it('updates sortBy config and persists it', async () => {
+    /** @type {import('../src/models.js').Config | null} */
+    let savedConfig = null
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: 'sortBy=label' }),
+      {
+        loadConfig: async () => makeConfig(),
+        saveConfig: async config => { savedConfig = config },
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(savedConfig).toEqual({
+      timeout: 0,
+      sortBy: 'label',
+      editor: ''
+    })
+    expect(stdout.write).toHaveBeenCalledWith('Updated config: sortBy=label\n')
+  })
+
+  it('fails for unknown config key', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: 'wat=x' }),
+      {
+        loadConfig: async () => makeConfig(),
+        saveConfig: async () => {},
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/unknown config key/i))
+  })
+
+  it('fails for invalid timeout', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: 'timeout=abc' }),
+      {
+        loadConfig: async () => makeConfig(),
+        saveConfig: async () => {},
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/invalid timeout/i))
+  })
+
+  it('updates editor config and persists it', async () => {
+    let savedConfig = null
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ configPresent: true, configArg: 'editor=nano' }),
+      {
+        loadConfig: async () => makeConfig(),
+        saveConfig: async config => { savedConfig = config },
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(savedConfig).toEqual({
+      timeout: 0,
+      sortBy: 'label',
+      editor: 'nano'
+    })
+    expect(stdout.write).toHaveBeenCalledWith('Updated config: editor=nano\n')
+  })
+})

--- a/test/delete.test.js
+++ b/test/delete.test.js
@@ -1,0 +1,128 @@
+import {describe, expect, it, vi} from "vitest";
+import {makeProfile} from "./fixtures/profiles.js";
+import {runCli} from "../src/cli-runner.js";
+import {makeCliArgs} from "./fixtures/cli.js";
+import {profilesRepositoryClassMock} from "./mocks/profiles-repository.js";
+
+describe('delete command', () => {
+  it('deletes an existing profile after confirmation', async () => {
+    const profiles = [
+      makeProfile({ label: 'github-main' }),
+      makeProfile({ label: 'gitlab-main', service: 'gitlab.com' })
+    ]
+    const repoMock = profilesRepositoryClassMock(profiles)
+
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ deleteLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        promptForConfirmation: async () => 'y',
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(repoMock.repo.delete).toHaveBeenCalledWith('github-main')
+    expect(repoMock.repo.persist).toHaveBeenCalled()
+    expect(repoMock.repo.list()).toHaveLength(1)
+    expect(repoMock.repo.list()[0].label).toBe('gitlab-main')
+    expect(stdout.write).toHaveBeenCalledWith("Deleted profile: 'github-main'\n")
+  })
+
+  it('cancels deletion on default response', async () => {
+    const profiles = [makeProfile({label: 'github-main'})]
+    const repoMock = profilesRepositoryClassMock(profiles)
+    const stdout = {write: vi.fn()}
+
+    const exitCode = await runCli(
+      makeCliArgs({deleteLabel: 'github-main'}),
+      {
+        ProfilesRepositoryClass: repoMock,
+        promptForConfirmation: async () => '',
+        stdout,
+        stderr: {write: vi.fn()}
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(repoMock.repo.list()).toHaveLength(1)
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
+    expect(stdout.write).toHaveBeenCalledWith('Cancelled\n')
+  })
+
+  it('cancels deletion on non-y response', async () => {
+    const profiles = [makeProfile({label: 'github-main'})]
+    const repoMock = profilesRepositoryClassMock(profiles)
+    const stdout = {write: vi.fn()}
+
+    const exitCode = await runCli(
+      makeCliArgs({deleteLabel: 'github-main'}),
+      {
+        ProfilesRepositoryClass: repoMock,
+        promptForConfirmation: async () => 'n',
+        stdout,
+        stderr: {write: vi.fn()}
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(repoMock.repo.list()).toHaveLength(1)
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
+    expect(stdout.write).toHaveBeenCalledWith('Cancelled\n')
+  })
+
+  it('fails when deleting a non-existent profile', async () => {
+    const profiles = [makeProfile({label: 'github-main'})]
+    const repoMock = profilesRepositoryClassMock(profiles)
+    const stderr = {write: vi.fn()}
+
+    const exitCode = await runCli(
+      makeCliArgs({deleteLabel: 'missing'}),
+      {
+        ProfilesRepositoryClass: repoMock,
+        promptForConfirmation: async () => 'y',
+        stdout: {write: vi.fn()},
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(repoMock.repo.list()).toHaveLength(1)
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/does not exist/i))
+  })
+
+  it('does not report deletion if save fails after confirmation', async () => {
+    const profiles = [
+      makeProfile({label: 'github-main'}),
+      makeProfile({label: 'gitlab-main', service: 'gitlab.com'})
+    ]
+    const repoMock = profilesRepositoryClassMock(profiles, {
+      persist: vi.fn(async () => {
+        throw new Error('disk full')
+      })
+    })
+
+    const stdout = {write: vi.fn()}
+    const stderr = {write: vi.fn()}
+
+    const exitCode = await runCli(
+      makeCliArgs({deleteLabel: 'github-main'}),
+      {
+        ProfilesRepositoryClass: repoMock,
+        promptForConfirmation: async () => 'y',
+        stdout,
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(repoMock.repo.delete).toHaveBeenCalled()
+    expect(repoMock.repo.persist).toHaveBeenCalled()
+    expect(stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('Deleted profile'))
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/disk full/i))
+  })
+})

--- a/test/editor.test.js
+++ b/test/editor.test.js
@@ -1,5 +1,522 @@
-import { describe, it, expect } from 'vitest'
-import { splitCommand } from '../src/editor.js'
+import {describe, it, expect, vi} from 'vitest'
+import {openInEditor, splitCommand} from '../src/editor.js'
+import {runCli} from "../src/cli-runner.js";
+import {makeCliArgs} from "./fixtures/cli.js";
+import {DEFAULT_PROFILE, makeProfile} from "./fixtures/profiles.js";
+import {profilesRepositoryClassMock} from "./mocks/profiles-repository.js";
+import {makeConfig} from "./fixtures/config.js";
+/** @typedef {import('../src/models.js').EditorSpawn} EditorSpawn */
+/** @typedef {import('node:child_process').ChildProcess} ChildProcess */
+
+describe('edit command', () => {
+  it('updates a profile after valid edit and confirmation', async () => {
+    const original = makeProfile({
+      label: 'github-main',
+      service: 'github.com',
+      account: 'peter@example.com',
+      counter: 4,
+      length: 20,
+      require: ['lower', 'upper', 'digit', 'symbol'],
+      symbolSet: '@!#'
+    })
+
+    const stdout = { write: vi.fn() }
+    const repoMock = profilesRepositoryClassMock([original])
+
+    const exitCode = await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        writeTempFile: async () => '/tmp/github-main_1776883800.json',
+        openInEditor: async () => 0,
+        readTempFile: async () => JSON.stringify({
+          service: 'github-enterprise.example.com',
+          account: 'peter@example.com',
+          counter: 4,
+          length: 20,
+          require: ['lower', 'upper', 'digit', 'symbol'],
+          symbolSet: '@!#'
+        }, null, 2),
+        deleteTempFile: async () => {},
+        promptForConfirmation: async () => 'y',
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(repoMock.repo.replace).toHaveBeenCalled()
+    const updated = repoMock.repo.replace.mock.calls[0][0]
+
+    expect(updated.createdAt).toBe(original.createdAt)
+    expect(updated.updatedAt).not.toBe(original.updatedAt)
+    expect(updated.service).toBe('github-enterprise.example.com')
+    expect(repoMock.repo.persist).toHaveBeenCalled()
+
+    const output = stdout.write.mock.calls.map(c => c[0]).join('')
+    expect(output).toMatch(/changed fields: service/i)
+    expect(output).toMatch(/will affect the generated password/i)
+    expect(output).toMatch(/Updated profile 'github-main'/)
+  })
+
+  it('prints no changes made when edited content is unchanged', async () => {
+    const original = makeProfile({label: 'github-main'})
+    const repoMock = profilesRepositoryClassMock([original])
+
+    let confirmCalled = false
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        writeTempFile: async () => '/tmp/github-main_1776883800.json',
+        openInEditor: async () => 0,
+        readTempFile: async () => JSON.stringify({
+          service: original.service,
+          account: original.account,
+          counter: original.counter,
+          length: original.length,
+          require: original.require,
+          symbolSet: original.symbolSet
+        }, null, 2),
+        deleteTempFile: async () => {},
+        promptForConfirmation: async () => {
+          confirmCalled = true
+          return 'y'
+        },
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(repoMock.repo.replace).not.toHaveBeenCalled()
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
+    expect(confirmCalled).toBe(false)
+    expect(stdout.write).toHaveBeenCalledWith('No changes made\n')
+  })
+
+  it('fails and does not persist on invalid JSON', async () => {
+    const original = makeProfile({label: 'github-main'})
+    const repoMock = profilesRepositoryClassMock([original])
+
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        writeTempFile: async () => '/tmp/github-main_1776883800.json',
+        openInEditor: async () => 0,
+        readTempFile: async () => '{ invalid json',
+        deleteTempFile: async () => {},
+        promptForConfirmation: async () => 'y',
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(repoMock.repo.replace).not.toHaveBeenCalled()
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/invalid json/i))
+  })
+
+  it('fails and does not persist on validation failure', async () => {
+    const original = makeProfile({label: 'github-main'})
+    const repoMock = profilesRepositoryClassMock([original])
+
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        writeTempFile: async () => '/tmp/github-main_1776883800.json',
+        openInEditor: async () => 0,
+        readTempFile: async () => JSON.stringify({
+          service: 'github.com',
+          account: 'peter@example.com',
+          counter: 4,
+          length: -1,
+          require: ['lower', 'upper'],
+          symbolSet: '@!#'
+        }, null, 2),
+        deleteTempFile: async () => {},
+        promptForConfirmation: async () => 'y',
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(repoMock.repo.replace).not.toHaveBeenCalled()
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/length/i))
+  })
+
+  it('fails for non-existent profile', async () => {
+    const stderr = { write: vi.fn() }
+    const repoMock = profilesRepositoryClassMock([DEFAULT_PROFILE])
+
+    const exitCode = await runCli(
+      makeCliArgs({ editLabel: 'missing' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(repoMock.repo.replace).not.toHaveBeenCalled()
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/Profile not found/i))
+  })
+
+  it('does not persist if editor exits non-zero', async () => {
+    const original = makeProfile({label: 'github-main'})
+    const repoMock = profilesRepositoryClassMock([original])
+
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        writeTempFile: async () => '/tmp/github-main_1776883800.json',
+        openInEditor: async () => 1,
+        deleteTempFile: async () => {},
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(repoMock.repo.replace).not.toHaveBeenCalled()
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
+
+    const output = stdout.write.mock.calls.map(c => c[0]).join('')
+    expect(output).not.toMatch(/Updated profile/i)
+  })
+
+  it('does not persist when confirmation is declined', async () => {
+    const original = makeProfile({label: 'github-main', service: 'github.com'})
+    const repoMock = profilesRepositoryClassMock([original])
+
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        writeTempFile: async () => '/tmp/github-main_1776883800.json',
+        openInEditor: async () => 0,
+        readTempFile: async () => JSON.stringify({
+          service: 'gitlab.com',
+          account: original.account,
+          counter: original.counter,
+          length: original.length,
+          require: original.require,
+          symbolSet: original.symbolSet
+        }, null, 2),
+        deleteTempFile: async () => {},
+        promptForConfirmation: async () => 'n',
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(repoMock.repo.replace).not.toHaveBeenCalled()
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
+
+    const output = stdout.write.mock.calls.map(c => c[0]).join('')
+    expect(output).toMatch(/changed fields: service/i)
+    expect(output).toMatch(/No changes saved/i)
+  })
+
+  it('uses editor from config when set', async () => {
+    const original = makeProfile({ label: 'github-main' })
+    const repoMock = profilesRepositoryClassMock([original])
+
+    let usedEditor = null
+
+    await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        loadConfig: async () => ({ editor: 'emacs' }),
+
+        writeTempFile: async () => '/tmp/file.json',
+        openInEditor: async (editor) => {
+          usedEditor = editor
+          return 1 // force early exit
+        },
+        deleteTempFile: async () => {},
+
+        stdout: { write: vi.fn() },
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(usedEditor).toBe('emacs')
+  })
+
+  it('uses $EDITOR when config editor is not set', async () => {
+    const original = makeProfile({ label: 'github-main' })
+    const repoMock = profilesRepositoryClassMock([original])
+
+    let usedEditor = null
+
+    const prev = process.env.EDITOR
+    process.env.EDITOR = 'nano'
+
+    try {
+      await runCli(
+        makeCliArgs({ editLabel: 'github-main' }),
+        {
+          ProfilesRepositoryClass: repoMock,
+          loadConfig: async () => ({}),
+
+          writeTempFile: async () => '/tmp/file.json',
+          openInEditor: async (editor) => {
+            usedEditor = editor
+            return 1
+          },
+          deleteTempFile: async () => {},
+
+          stdout: { write: vi.fn() },
+          stderr: { write: vi.fn() }
+        }
+      )
+    } finally {
+      process.env.EDITOR = prev
+    }
+
+    expect(usedEditor).toBe('nano')
+  })
+
+  it('falls back to default editor when config and $EDITOR are not set', async () => {
+    const original = makeProfile({ label: 'github-main' })
+    const repoMock = profilesRepositoryClassMock([original])
+
+    let usedEditor = null
+
+    const prev = process.env.EDITOR
+    delete process.env.EDITOR
+
+    try {
+      await runCli(
+        makeCliArgs({ editLabel: 'github-main' }),
+        {
+          ProfilesRepositoryClass: repoMock,
+          loadConfig: async () => ({}),
+
+          writeTempFile: async () => '/tmp/file.json',
+          openInEditor: async (editor) => {
+            usedEditor = editor
+            return 1
+          },
+          deleteTempFile: async () => {},
+
+          stdout: { write: vi.fn() },
+          stderr: { write: vi.fn() }
+        }
+      )
+    } finally {
+      process.env.EDITOR = prev
+    }
+
+    expect(usedEditor).toBe('vi')
+  })
+
+  it('cleans up the temp file after a successful edit', async () => {
+    const original = makeProfile({label: 'github-main', service: 'github.com'})
+    const repoMock = profilesRepositoryClassMock([original])
+
+    let deletedPath = null
+
+    const exitCode = await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        writeTempFile: async () => '/tmp/github-main_1776883800.json',
+        openInEditor: async () => 0,
+        readTempFile: async () => JSON.stringify({
+          service: 'gitlab.com',
+          account: original.account,
+          counter: original.counter,
+          length: original.length,
+          require: original.require,
+          symbolSet: original.symbolSet
+        }, null, 2),
+        deleteTempFile: async (filePath) => {
+          deletedPath = filePath
+        },
+        promptForConfirmation: async () => 'y',
+        stdout: { write: vi.fn() },
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(deletedPath).toBe('/tmp/github-main_1776883800.json')
+  })
+
+  it('cleans up the temp file when edited JSON is invalid', async () => {
+    const original = makeProfile({ label: 'github-main' })
+    const repoMock = profilesRepositoryClassMock([original])
+
+    let deletedPath = null
+
+    const exitCode = await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        writeTempFile: async () => '/tmp/github-main_1776883800.json',
+        openInEditor: async () => 0,
+        readTempFile: async () => '{ invalid json',
+        deleteTempFile: async (filePath) => {
+          deletedPath = filePath
+        },
+        promptForConfirmation: async () => 'y',
+        stdout: { write: vi.fn() },
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(deletedPath).toBe('/tmp/github-main_1776883800.json')
+  })
+
+  it('fails and does not persist when require contains unknown values', async () => {
+    const original = makeProfile({ label: 'github-main' })
+    const repoMock = profilesRepositoryClassMock([original])
+
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        writeTempFile: async () => '/tmp/file.json',
+        openInEditor: async () => 0,
+        readTempFile: async () => JSON.stringify({
+          service: 'github.com',
+          account: original.account,
+          counter: original.counter,
+          length: original.length,
+          require: ['runes', 'upper'],
+          symbolSet: original.symbolSet
+        }, null, 2),
+        deleteTempFile: async () => {},
+        promptForConfirmation: async () => 'y',
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(repoMock.repo.replace).not.toHaveBeenCalled()
+    expect(repoMock.repo.persist).not.toHaveBeenCalled()
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/Unknown character class/i))
+  })
+  it('uses editor command with arguments from config', async () => {
+    const original = makeProfile({ label: 'github-main' })
+    const repoMock = profilesRepositoryClassMock([original])
+
+    let usedEditor = null
+
+    await runCli(
+      makeCliArgs({ editLabel: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        loadConfig: async () => makeConfig({ editor: 'code --wait' }),
+        writeTempFile: async () => '/tmp/file.json',
+        openInEditor: async (editor) => {
+          usedEditor = editor
+          return 1
+        },
+        deleteTempFile: async () => {},
+        stdout: { write: vi.fn() },
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(usedEditor).toBe('code --wait')
+  })
+
+  it('splits editor command and appends file path', async () => {
+    let spawnedCommand = null
+    let spawnedArgs = null
+
+    const fakeSpawn =
+      /** @type {EditorSpawn} */ (
+      /** @type {unknown} */ (
+        /**
+         * @param {string} command
+         * @param {readonly string[]} args
+         * @param {object=} _options
+         * @returns {ChildProcess}
+         */
+          (command, args, _options) => {
+          spawnedCommand = command
+          spawnedArgs = [...args]
+
+          return /** @type {ChildProcess} */ ({
+            on: (
+              /** @type {'error' | 'close'} */ event,
+              /** @type {(value: any) => void} */ handler
+            ) => {
+              if (event === 'close') handler(0)
+            }
+          })
+        }
+      )
+    )
+
+    await openInEditor('code --wait', '/tmp/file.json', fakeSpawn)
+
+    expect(spawnedCommand).toBe('code')
+    expect(spawnedArgs).toEqual(['--wait', '/tmp/file.json'])
+  })
+
+  it('supports quoted editor paths', async () => {
+    let spawnedCommand = null
+    let spawnedArgs = null
+
+    const fakeSpawn =
+      /** @type {EditorSpawn} */ (
+      /** @type {unknown} */ (
+        /**
+         * @param {string} command
+         * @param {readonly string[]} args
+         * @param {object=} _options
+         * @returns {ChildProcess}
+         */
+          (command, args, _options) => {
+          spawnedCommand = command
+          spawnedArgs = [...args]
+
+          return /** @type {ChildProcess} */ ({
+            on: (
+              /** @type {'error' | 'close'} */ event,
+              /** @type {(value: any) => void} */ handler
+            ) => {
+              if (event === 'close') handler(0)
+            }
+          })
+        }
+      )
+    )
+
+    await openInEditor('"C:\\Program Files\\Editor\\editor.exe" --wait', 'C:\\tmp\\file.json', fakeSpawn)
+    expect(spawnedCommand).toBe('C:\\Program Files\\Editor\\editor.exe')
+    expect(spawnedArgs).toEqual(['--wait', 'C:\\tmp\\file.json'])
+  })
+})
 
 describe('splitCommand', () => {
   it('splits command with arguments', () => {

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { runCli } from '../src/cli-runner.js'
 import { makeProfile } from './fixtures/profiles.js'
 import { makeCliArgs } from './fixtures/cli.js'
+import { profilesRepositoryClassMock } from './mocks/profiles-repository.js'
 
 describe('list command', () => {
   it('prints all profiles in sorted order', async () => {
@@ -15,7 +16,7 @@ describe('list command', () => {
     const exitCode = await runCli(
       makeCliArgs({ list: true }),
       {
-        loadAllProfiles: async () => profiles,
+        ProfilesRepositoryClass: profilesRepositoryClassMock(profiles),
         stdout,
         stderr: { write: vi.fn() }
       }
@@ -36,7 +37,7 @@ describe('list command', () => {
     const exitCode = await runCli(
       makeCliArgs({ list: true }),
       {
-        loadAllProfiles: async () => [],
+        ProfilesRepositoryClass: profilesRepositoryClassMock([]),
         stdout,
         stderr: { write: vi.fn() }
       }

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -2,8 +2,45 @@ import { describe, it, expect, vi } from 'vitest'
 import { runCli } from '../src/cli-runner.js'
 import { makeProfile } from './fixtures/profiles.js'
 import { makeCliArgs } from './fixtures/cli.js'
+import { profilesRepositoryClassMock } from './mocks/profiles-repository.js'
+import {createDefaultProfile} from "../src/profile-factory.js";
 
 describe('list command', () => {
+  it('new profile is visible in list output', async () => {
+    const created = createDefaultProfile('github-main', '2026-04-14T12:00:00.000Z')
+    const repoMock = profilesRepositoryClassMock([created])
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ list: true }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(repoMock.load).toHaveBeenCalled()
+    expect(stdout.write).toHaveBeenCalledWith(expect.stringMatching(/github-main/))
+  })
+
+  it('treats missing profiles file as empty list', async () => {
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ list: true }),
+      {
+        ProfilesRepositoryClass: profilesRepositoryClassMock([]),
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stdout.write).toHaveBeenCalledWith('label  counter\n')
+  })
+
   it('prints all profiles in sorted order', async () => {
     const profiles = [
       makeProfile({ label: 'zeta', service: 'z.com' }),
@@ -15,7 +52,7 @@ describe('list command', () => {
     const exitCode = await runCli(
       makeCliArgs({ list: true }),
       {
-        loadAllProfiles: async () => profiles,
+        ProfilesRepositoryClass: profilesRepositoryClassMock(profiles),
         stdout,
         stderr: { write: vi.fn() }
       }
@@ -36,7 +73,7 @@ describe('list command', () => {
     const exitCode = await runCli(
       makeCliArgs({ list: true }),
       {
-        loadAllProfiles: async () => [],
+        ProfilesRepositoryClass: profilesRepositoryClassMock([]),
         stdout,
         stderr: { write: vi.fn() }
       }

--- a/test/mocks/profiles-repository.js
+++ b/test/mocks/profiles-repository.js
@@ -5,32 +5,44 @@ import { vi } from 'vitest'
 
 /**
  * @param {Profile[]} initialProfiles
- * @returns {ProfilesRepositoryFactory & { load: import('vitest').Mock }}
+ * @param {Partial<{
+ *   create: Function,
+ *   replace: Function,
+ *   delete: Function,
+ *   persist: Function
+ * }>} [overrides]
+ * @returns {ProfilesRepositoryFactory & { load: import('vitest').Mock, repo: any }}
  */
-export function profilesRepositoryClassMock(initialProfiles) {
+export function profilesRepositoryClassMock(initialProfiles, overrides = {}) {
   let profiles = [...initialProfiles]
 
+  const repo = {
+    list: () => [...profiles],
+
+    get: (/** @type {string} */ label) =>
+      profiles.find(p => p.label === label) ?? null,
+
+    create: vi.fn(profile => {
+      profiles.push(profile)
+    }),
+
+    replace: vi.fn(profile => {
+      const i = profiles.findIndex(p => p.label === profile.label)
+      if (i !== -1) profiles[i] = profile
+    }),
+
+    delete: vi.fn(label => {
+      profiles = profiles.filter(p => p.label !== label)
+    }),
+
+    persist: vi.fn(async () => {
+    }),
+
+    ...overrides
+  }
+
   return {
-    load: vi.fn(async () => ({
-      list: () => [...profiles],
-
-      get: (/** @type {string} */ label) =>
-        profiles.find(p => p.label === label) ?? null,
-
-      create: (profile) => {
-        profiles.push(profile)
-      },
-
-      replace: (profile) => {
-        const i = profiles.findIndex(p => p.label === profile.label)
-        if (i !== -1) profiles[i] = profile
-      },
-
-      delete: (/** @type {string} */ label) => {
-        profiles = profiles.filter(p => p.label !== label)
-      },
-
-      persist: vi.fn(async () => {})
-    }))
+    load: vi.fn(async () => repo),
+    repo
   }
 }

--- a/test/mocks/profiles-repository.js
+++ b/test/mocks/profiles-repository.js
@@ -1,0 +1,36 @@
+import { vi } from 'vitest'
+
+/** @typedef {import('../../src/models.js').Profile} Profile */
+/** @typedef {import('../../src/models.js').ProfilesRepositoryFactory} ProfilesRepositoryFactory */
+
+/**
+ * @param {Profile[]} initialProfiles
+ * @returns {ProfilesRepositoryFactory & { load: import('vitest').Mock }}
+ */
+export function profilesRepositoryClassMock(initialProfiles) {
+  let profiles = [...initialProfiles]
+
+  return {
+    load: vi.fn(async () => ({
+      list: () => [...profiles],
+
+      get: (/** @type {string} */ label) =>
+        profiles.find(p => p.label === label) ?? null,
+
+      create: (profile) => {
+        profiles.push(profile)
+      },
+
+      replace: (profile) => {
+        const i = profiles.findIndex(p => p.label === profile.label)
+        if (i !== -1) profiles[i] = profile
+      },
+
+      delete: (/** @type {string} */ label) => {
+        profiles = profiles.filter(p => p.label !== label)
+      },
+
+      persist: vi.fn(async () => {})
+    }))
+  }
+}

--- a/test/mocks/profiles-repository.js
+++ b/test/mocks/profiles-repository.js
@@ -1,0 +1,51 @@
+import { vi } from 'vitest'
+
+/** @typedef {import('../../src/models.js').Profile} Profile */
+/** @typedef {import('../../src/models.js').ProfilesRepositoryFactory} ProfilesRepositoryFactory */
+/**
+ * @typedef {{
+ *   create?: (profile: Profile) => void,
+ *   replace?: (profile: Profile) => void,
+ *   delete?: (label: string) => void,
+ *   persist?: () => Promise<void>
+ * }} RepoOverrides
+ */
+
+/**
+ * @param {Profile[]} initialProfiles
+ * @param {RepoOverrides} [overrides]
+ * @returns {ProfilesRepositoryFactory & { load: import('vitest').Mock, repo: any }}
+ */
+export function profilesRepositoryClassMock(initialProfiles, overrides = {}) {
+  let profiles = [...initialProfiles]
+
+  const repo = {
+    list: () => [...profiles],
+
+    get: (/** @type {string} */ label) =>
+      profiles.find(p => p.label === label) ?? null,
+
+    create: vi.fn(profile => {
+      profiles.push(profile)
+    }),
+
+    replace: vi.fn(profile => {
+      const i = profiles.findIndex(p => p.label === profile.label)
+      if (i !== -1) profiles[i] = profile
+    }),
+
+    delete: vi.fn(label => {
+      profiles = profiles.filter(p => p.label !== label)
+    }),
+
+    persist: vi.fn(async () => {
+    }),
+
+    ...overrides
+  }
+
+  return {
+    load: vi.fn(async () => repo),
+    repo
+  }
+}

--- a/test/new.test.js
+++ b/test/new.test.js
@@ -1,0 +1,49 @@
+import {describe, expect, it, vi} from "vitest";
+import {runCli} from "../src/cli-runner.js";
+import {makeCliArgs} from "./fixtures/cli.js";
+import {profilesRepositoryClassMock} from "./mocks/profiles-repository.js";
+import {DEFAULT_PROFILE} from "./fixtures/profiles.js";
+
+describe('new command', () => {
+  it('creates a new profile', async () => {
+    const repoMock = profilesRepositoryClassMock([])
+    const stdout = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ create: 'github-main' }),
+      {
+        ProfilesRepositoryClass: repoMock,
+        stdout,
+        stderr: { write: vi.fn() }
+      }
+    )
+
+    expect(exitCode).toBe(0)
+
+    expect(repoMock.repo.create).toHaveBeenCalled()
+    expect(repoMock.repo.persist).toHaveBeenCalled()
+    const savedProfile = repoMock.repo.get('github-main')
+    expect(savedProfile).not.toBeNull()
+    expect(savedProfile.service).toBe('github-main')
+    expect(savedProfile.counter).toBe(0)
+    expect(savedProfile.require.length).toBe(4)
+    expect(savedProfile.length).toBe(20)
+    expect(stdout.write).toHaveBeenCalledWith("Created profile: 'github-main'\n")
+  })
+
+  it('fails when creating a duplicate profile', async () => {
+    const stderr = { write: vi.fn() }
+
+    const exitCode = await runCli(
+      makeCliArgs({ create: 'github-main' }),
+      {
+        ProfilesRepositoryClass: profilesRepositoryClassMock([DEFAULT_PROFILE]),
+        stdout: { write: vi.fn() },
+        stderr
+      }
+    )
+
+    expect(exitCode).toBe(1)
+    expect(stderr.write).toHaveBeenCalledWith(expect.stringMatching(/already exists/i))
+  })
+})

--- a/test/profiles-file.test.js
+++ b/test/profiles-file.test.js
@@ -1,10 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { tmpdir } from 'node:os'
-import fs from 'node:fs/promises'
-import { mkdtemp } from 'node:fs/promises'
 import path from 'node:path'
-import {resolveProfilesPath, findProfileByLabel, loadProfileByLabel, loadAllProfiles} from '../src/profiles-file.js'
-import { makeProfile } from './fixtures/profiles.js'
+import {resolveProfilesPath, loadAllProfiles} from '../src/profiles-file.js'
 
 describe('resolveProfilesPath', () => {
   it('uses ~/.dpg-v2/profiles.json on macOS', () => {
@@ -44,52 +40,7 @@ describe('resolveProfilesPath', () => {
   })
 })
 
-describe('findProfileByLabel', () => {
-  it('returns the matching profile', () => {
-    const profiles = [
-      makeProfile({ label: 'github-main' }),
-      makeProfile({ label: 'gitlab-main', service: 'gitlab.com' })
-    ]
-
-    const result = findProfileByLabel(profiles, 'github-main')
-
-    expect(result.label).toBe('github-main')
-    expect(result.service).toBe('github.com')
-  })
-
-  it('throws if profile is not found', () => {
-    const profiles = [makeProfile({ label: 'github-main' })]
-
-    expect(() => findProfileByLabel(profiles, 'missing'))
-      .toThrow(/profile not found/i)
-  })
-
-  it('throws if profiles root is not an array', () => {
-    expect(() => findProfileByLabel({}, 'github-main'))
-      .toThrow(/array/i)
-  })
-})
-
-describe('loadProfileByLabel', () => {
-  it('loads a matching profile from disk', async () => {
-    const dir = await mkdtemp(path.join(tmpdir(), 'dpg-'))
-    const profilesPath = path.join(dir, 'profiles.json')
-
-    await fs.writeFile(
-      profilesPath,
-      JSON.stringify([
-        makeProfile({ label: 'github-main' }),
-        makeProfile({ label: 'gitlab-main', service: 'gitlab.com' })
-      ]),
-      'utf8'
-    )
-
-    const result = await loadProfileByLabel('gitlab-main', { profilesPath })
-
-    expect(result.label).toBe('gitlab-main')
-    expect(result.service).toBe('gitlab.com')
-  })
-
+describe('missing profiles file', () => {
   it('returns empty array when profiles file is missing', async () => {
     const missingPath = path.join('/definitely', 'not-there', 'profiles.json')
     const result = await loadAllProfiles({ profilesPath: missingPath })

--- a/test/profiles-repository.test.js
+++ b/test/profiles-repository.test.js
@@ -78,4 +78,37 @@ describe('ProfilesRepository methods', () => {
     const saved = JSON.parse(await fs.readFile(profilesPath, 'utf8'))
     expect(saved).toHaveLength(1)
   })
+
+  it('throws when replacing non-existent profile', async () => {
+    const repo = await ProfilesRepository.load({
+      loadAllProfiles: async () => []
+    })
+
+    expect(() =>
+      repo.replace(makeProfile({ label: 'ghost' }))
+    ).toThrow(/does not exist/)
+  })
+
+  it('throws when creating duplicate label', async () => {
+    const repo = await ProfilesRepository.load({
+      loadAllProfiles: async () => [
+        makeProfile({ label: 'github' })
+      ]
+    })
+
+    expect(() =>
+      repo.create(makeProfile({ label: 'github' }))
+    ).toThrow(/already exists/)
+  })
+
+
+  it('throws when deleting non-existent profile', async () => {
+    const repo = await ProfilesRepository.load({
+      loadAllProfiles: async () => []
+    })
+
+    expect(() =>
+      repo.delete('ghost')
+    ).toThrow(/does not exist/)
+  })
 })

--- a/test/profiles-repository.test.js
+++ b/test/profiles-repository.test.js
@@ -1,0 +1,66 @@
+import {it, expect, describe} from 'vitest'
+import {ProfilesRepository} from "../src/profiles-repository.js";
+import {loadAllProfiles} from "../src/profiles-file.js";
+import {makeProfile} from "./fixtures/profiles.js";
+/** @typedef {import('../src/models.js').Profile} Profile */
+
+describe('ProfilesRepository methods', () => {
+  it('loads profiles and lists them', async () => {
+    const repo = await ProfilesRepository.load({loadAllProfiles})
+
+    const profiles = repo.list()
+
+    expect(profiles.length).toBeGreaterThan(0)
+  })
+
+  it('returns profile by label', async () => {
+    const repo = await ProfilesRepository.load({loadAllProfiles})
+
+    const profile = repo.get('github-main')
+
+    expect(profile.label).toBe('github-main')
+  })
+
+  it('creates a new profile', async () => {
+    const repo = await ProfilesRepository.load({loadAllProfiles})
+
+    repo.create(makeProfile({label: 'new-profile'}))
+
+    expect(repo.get('new-profile')).not.toBeNull()
+  })
+
+  it('replaces an existing profile', async () => {
+    const repo = await ProfilesRepository.load({loadAllProfiles})
+
+    const updated = makeProfile({label: 'github-main', counter: 42})
+
+    repo.replace(updated)
+
+    expect(repo.get('github-main').counter).toBe(42)
+  })
+
+  it('deletes a profile', async () => {
+    const repo = await ProfilesRepository.load({loadAllProfiles})
+
+    repo.delete('github-main')
+
+    expect(repo.get('github-main')).toBeNull()
+  })
+
+  it('persists profiles', async () => {
+    /** @type {Profile[]} */
+    let saved = null
+
+    const repo = await ProfilesRepository.load({
+      loadAllProfiles,
+      saveProfiles: async profiles => {
+        saved = profiles
+      }
+    })
+
+    repo.create(makeProfile({label: 'new-profile'}))
+    await repo.persist()
+
+    expect(saved.some(p => p.label === 'new-profile')).toBe(true)
+  })
+})

--- a/test/profiles-repository.test.js
+++ b/test/profiles-repository.test.js
@@ -1,0 +1,81 @@
+import {it, expect, describe} from 'vitest'
+import {ProfilesRepository} from "../src/profiles-repository.js";
+import {makeProfile} from "./fixtures/profiles.js";
+import fs from 'node:fs/promises'
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { loadAllProfiles, saveProfiles } from '../src/profiles-file.js'
+/** @typedef {import('../src/models.js').Profile} Profile */
+
+const _loadAllProfiles = async () => [makeProfile({label: 'github-main'})]
+
+describe('ProfilesRepository methods', () => {
+  it('loads profiles and lists them', async () => {
+    const repo = await ProfilesRepository.load({loadAllProfiles: _loadAllProfiles})
+
+    expect(repo.list()).toHaveLength(1)
+  })
+
+  it('returns profile by label', async () => {
+    const repo = await ProfilesRepository.load({loadAllProfiles: _loadAllProfiles})
+
+    expect(repo.get('github-main')?.label).toBe('github-main')
+  })
+
+  it('creates a new profile', async () => {
+    const repo = await ProfilesRepository.load({loadAllProfiles: _loadAllProfiles})
+
+    repo.create(makeProfile({label: 'new-profile'}))
+
+    expect(repo.get('new-profile')).not.toBeNull()
+  })
+
+  it('replaces an existing profile', async () => {
+    const repo = await ProfilesRepository.load({loadAllProfiles: _loadAllProfiles})
+
+    repo.replace(makeProfile({label: 'github-main', counter: 42}))
+
+    expect(repo.get('github-main')?.counter).toBe(42)
+  })
+
+  it('deletes a profile', async () => {
+    const repo = await ProfilesRepository.load({loadAllProfiles: _loadAllProfiles})
+
+    repo.delete('github-main')
+
+    expect(repo.get('github-main')).toBeNull()
+  })
+
+  it('persists profiles', async () => {
+    /** @type {Profile[]} */
+    let saved = null
+
+    const repo = await ProfilesRepository.load({
+      loadAllProfiles: _loadAllProfiles,
+      saveProfiles: async profiles => {
+        saved = profiles
+      }
+    })
+
+    repo.create(makeProfile({label: 'new-profile'}))
+    await repo.persist()
+
+    expect(saved.some(p => p.label === 'new-profile')).toBe(true)
+  })
+
+  it('creates profiles file when none exists', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'dpg-'))
+    const profilesPath = path.join(dir, 'profiles.json')
+
+    const repo = await ProfilesRepository.load({
+      loadAllProfiles: () => loadAllProfiles({ profilesPath }),
+      saveProfiles: profiles => saveProfiles(profiles, { profilesPath })
+    })
+
+    repo.create(makeProfile({ label: 'github-main' }))
+    await repo.persist()
+
+    const saved = JSON.parse(await fs.readFile(profilesPath, 'utf8'))
+    expect(saved).toHaveLength(1)
+  })
+})

--- a/test/profiles-repository.test.js
+++ b/test/profiles-repository.test.js
@@ -1,24 +1,21 @@
 import {it, expect, describe} from 'vitest'
 import {ProfilesRepository} from "../src/profiles-repository.js";
-import {loadAllProfiles} from "../src/profiles-file.js";
 import {makeProfile} from "./fixtures/profiles.js";
 /** @typedef {import('../src/models.js').Profile} Profile */
+
+const loadAllProfiles = async () => [makeProfile({label: 'github-main'})]
 
 describe('ProfilesRepository methods', () => {
   it('loads profiles and lists them', async () => {
     const repo = await ProfilesRepository.load({loadAllProfiles})
 
-    const profiles = repo.list()
-
-    expect(profiles.length).toBeGreaterThan(0)
+    expect(repo.list()).toHaveLength(1)
   })
 
   it('returns profile by label', async () => {
     const repo = await ProfilesRepository.load({loadAllProfiles})
 
-    const profile = repo.get('github-main')
-
-    expect(profile.label).toBe('github-main')
+    expect(repo.get('github-main')?.label).toBe('github-main')
   })
 
   it('creates a new profile', async () => {
@@ -32,11 +29,9 @@ describe('ProfilesRepository methods', () => {
   it('replaces an existing profile', async () => {
     const repo = await ProfilesRepository.load({loadAllProfiles})
 
-    const updated = makeProfile({label: 'github-main', counter: 42})
+    repo.replace(makeProfile({label: 'github-main', counter: 42}))
 
-    repo.replace(updated)
-
-    expect(repo.get('github-main').counter).toBe(42)
+    expect(repo.get('github-main')?.counter).toBe(42)
   })
 
   it('deletes a profile', async () => {


### PR DESCRIPTION
# DPG-034: Introduce ProfilesRepository and complete CLI migration

## Summary
Introduce a centralized ProfilesRepository abstraction and refactor the CLI to use it as the sole interface for profile lifecycle operations.

## Changes

### Repository
- Add `ProfilesRepository` with:
  - `load`, `list`, `get`
  - `create`, `replace`, `delete`
  - `persist`
- Move persistence logic (`loadAllProfiles`, `saveProfiles`) behind repository boundary
- Establish repository as owner of profile collection and invariants

### CLI refactor
- Migrate all commands to use repository:
  - `--list`
  - `--show-profile`
  - `--profile`
  - `--delete`
  - `--bump` / `--bump --save`
  - `--edit`
  - `--new`
- Remove direct file access and profile array manipulation from CLI
- Remove obsolete helpers:
  - `loadProfileByLabel`
  - `findProfileByLabel`
- Remove `loadAllProfiles` and `saveProfiles` from `CliDeps`

### Tests
- Replace file-level mocks with repository mocks in CLI tests
- Introduce stateful `profilesRepositoryClassMock`
- Move persistence-related tests to `profiles-repository.test.js`
- Split large `cli-flow.test.js` into command-focused test files:
  - `bump.test.js`
  - `delete.test.js`
  - `new.test.js`
  - `list.test.js`
  - `editor.test.js`
- Retain `cli-flow.test.js` for orchestration and smoke tests

## Result
- Clear separation between CLI and persistence layers
- Repository is single source of truth for profile operations
- Tests are smaller, focused, and decoupled from filesystem
- CLI no longer depends on storage implementation

## Notes
- This establishes the foundation for DPG-026 (duplicate detection)
- Behavior unchanged; all tests passing