### PR TITLE
DPG-035: Adaptive abbreviated context hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,27 @@ jobs:
         run: npm link
 
       - name: Run TSV integration harness
-        run: ./integration/run.sh
+        run: npm run test:integration
+
+  short-hash-integration:
+    name: Short Hash expansion integration test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Link local CLI
+        run: npm link
+
+      - name: Run short-hash collision expansion test
+        run: npm run test:short-hash

--- a/README.md
+++ b/README.md
@@ -384,6 +384,8 @@ Duplicate detection works by grouping profiles with matching `ctxHash` values.
 
 Missing hashes are automatically backfilled when profiles are loaded.
 
+`hashAbbrev` is managed automatically by DPG and should not be edited manually.
+
 ### Important note about manual editing
 
 Manual editing of `profiles.json` is strongly discouraged.

--- a/README.md
+++ b/README.md
@@ -307,9 +307,10 @@ Prints the current config as pretty-printed JSON.
     dpg-cli --config sortBy=label
 
 Supported keys:
-- `timeout` — non-negative integer seconds
-- `sortBy` — currently only `label`
 - `editor` — your preferred tool for editing profiles
+- `hashAbbrev` — internal used, defaults to 7
+- `sortBy` — currently only `label`
+- `timeout` — non-negative integer seconds
 
 ### Help
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,5 +1,6 @@
 {
-  "timeout": 60,
+  "editor": "nano",
+  "hashAbbrev": 7,
   "sortBy": "label",
-  "editor": "nano"
+  "timeout": 60
 }

--- a/integration/config.json
+++ b/integration/config.json
@@ -1,5 +1,6 @@
 {
-  "timeout":90,
+  "editor":"notepad.exe",
+  "hashAbbrev": 7,
   "sortBy":"label",
-  "editor":"notepad.exe"
+  "timeout":90
 }

--- a/integration/fake-edits/req_2
+++ b/integration/fake-edits/req_2
@@ -3,6 +3,6 @@
   "counter": 0,
   "length": 20,
   "require": ["runes","upper","digit","symbol"],
-  "comment": "bad require class 'runes'",
-  "symbolSet": "@!#"
+  "symbolSet": "@!#",
+  "notes": "bad require class 'runes'"
 }

--- a/integration/fake-edits/sym_2
+++ b/integration/fake-edits/sym_2
@@ -4,5 +4,5 @@
   "length": 20,
   "require": ["lower","upper","digit","symbol"],
   "symbolSet": "@!#!",
-  "comment": "duplicated '!' in symbolSet"
+  "notes": "duplicated '!' in symbolSet"
 }

--- a/integration/short-hash/README.md
+++ b/integration/short-hash/README.md
@@ -1,0 +1,198 @@
+# Short Hash Expansion Tests
+
+This directory contains a dedicated integration/performance test suite for DPG's adaptive abbreviated context hash system (`ctxHash`).
+
+The goal of these tests is to validate:
+
+- abbreviated-hash collision handling
+- automatic `hashAbbrev` expansion
+- persistence correctness
+- performance characteristics
+- suitability of the default `hashAbbrev` value
+
+---
+
+## Background
+
+DPG stores abbreviated context hashes in `profiles.json` in order to keep profile files compact while still allowing efficient duplicate-context detection.
+
+This behaves similarly to Git's abbreviated commit hashes:
+
+- short hashes are used in the common case
+- collisions are detected automatically
+- abbreviation length expands only when needed
+- correctness is preserved at all times
+
+The repository owns this maintenance transparently during persistence.
+
+---
+
+## Why These Tests Exist
+
+Abbreviated-hash collisions are intentionally rare in normal usage.
+
+That makes them awkward to test using ordinary unit or TSV-driven integration tests.
+
+This suite deliberately starts from an artificially tiny value:
+
+```json
+{
+  "hashAbbrev": 1
+}
+```
+
+and repeatedly creates profiles until automatic expansion occurs.
+
+This allows us to:
+
+- verify expansion correctness
+- measure persistence cost
+- estimate realistic collision frequency
+- validate the default starting value
+
+---
+
+## Safety
+
+The script runs entirely inside a temporary `$HOME` directory.
+
+It does **not** touch the developer's real:
+
+- `~/.dpg-v2/config.json`
+- `~/.dpg-v2/profiles.json`
+
+The temporary environment is automatically removed on completion or interruption.
+
+---
+
+## Measured Results
+
+Measured on a 2019 Intel MacBook Pro.
+
+### Expansion thresholds
+
+| hashAbbrev reached | profiles required |
+|--------------------|------------------:|
+| 2                  |                 3 |
+| 3                  |                29 |
+| 4                  |                85 |
+| 5                  |               252 |
+| 6                  |               408 |
+| 7                  |              1409 |
+
+### Representative timings
+
+| profiles              | hashAbbrev | duration |
+|-----------------------|-----------:|---------:|
+| 1                     |          1 |    171ms |
+| 10                    |          2 |    186ms |
+| 25                    |          2 |    190ms |
+| 50                    |          3 |    192ms |
+| 100                   |          4 |    190ms |
+| 250                   |          4 |    186ms |
+| 500                   |          6 |    193ms |
+| 1000                  |          6 |    357ms |
+| 1409 (expansion to 7) |          7 |    577ms |
+
+---
+
+## Observations
+
+### Adaptive expansion is inexpensive
+
+Even at more than 1400 profiles, the expansion event itself remained comfortably below one second.
+
+This validates the decision to keep adaptive hash maintenance completely silent during normal CLI usage.
+
+No progress or status message is currently required.
+
+### `hashAbbrev = 7` is a strong default
+
+Reaching length 7 required more than 1400 generated profiles.
+
+This is far beyond the expected profile count for typical users.
+
+In normal real-world usage, expansion beyond 7 is expected to be extremely rare.
+
+### Persistence overhead remains small
+
+Even with 1000 profiles:
+
+```text
+duration=357ms
+```
+
+for a normal profile creation operation.
+
+This suggests that the adaptive collision checks scale well for realistic repository sizes.
+
+---
+
+## Running The Tests
+
+Run the suite via:
+
+```bash
+npm run test:short-hash
+```
+
+---
+
+## Configuration
+
+The script exposes two useful tuning variables near the top:
+
+```bash
+HASH_LIMIT=3
+HARD_STOP=500
+```
+
+### `HASH_LIMIT`
+
+Controls how far the adaptive expansion should run before stopping.
+
+Examples:
+
+| HASH_LIMIT | Expected runtime |
+|------------|-----------------:|
+| 3          |          seconds |
+| 4          |   under 1 minute |
+| 5          |       ~2 minutes |
+| 6          |     ~3–5 minutes |
+| 7          |   ~15–20 minutes |
+
+These are approximate timings from the 2019 Intel MacBook Pro test machine.
+
+Faster CI runners may complete somewhat sooner.
+
+### `HARD_STOP`
+
+Maximum number of generated profiles before the test aborts.
+
+This is a safety guard to prevent accidental runaway runs.
+
+Recommended values:
+
+| HASH_LIMIT | Suggested HARD_STOP |
+|------------|--------------------:|
+| 3          |                 500 |
+| 4          |                 500 |
+| 5          |                1000 |
+| 6          |                2000 |
+| 7          |                3000 |
+
+---
+
+## Notes
+
+These tests intentionally exercise pathological collision scenarios by starting from `hashAbbrev = 1`.
+
+Real-world repositories start at the default:
+
+```json
+{
+  "hashAbbrev": 7
+}
+```
+
+and therefore experience dramatically fewer collision checks and expansions.

--- a/integration/short-hash/run.sh
+++ b/integration/short-hash/run.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REAL_HOME="$HOME"
+TEST_HOME="$(mktemp -d)"
+HASH_LIMIT=4
+HARD_STOP=500
+
+cleanup() {
+  export HOME="$REAL_HOME"
+  rm -rf "$TEST_HOME"
+}
+
+on_interrupt() {
+  cleanup
+  exit 130
+}
+
+trap cleanup EXIT
+trap on_interrupt INT TERM
+
+export HOME="$TEST_HOME"
+
+DPG_DIR="${HOME}/.dpg-v2"
+CONFIG_FILE="${DPG_DIR}/config.json"
+PROFILES_FILE="${DPG_DIR}/profiles.json"
+
+mkdir -p "$DPG_DIR"
+
+cat > "$CONFIG_FILE" <<'JSON'
+{
+  "timeout": 90,
+  "sortBy": "label",
+  "editor": "",
+  "hashAbbrev": 1
+}
+JSON
+
+cat > "$PROFILES_FILE" <<'JSON'
+[]
+JSON
+
+echo "Running short-hash expansion test..."
+echo "Test HOME: $TEST_HOME"
+echo
+START_TS=$(date +%s)
+START_TIME=$(date +"%H:%M:%S")
+
+n=0
+
+while true; do
+  label=$(printf "label_%04d" "$n")
+
+  start_ms=$(node -e 'console.log(Date.now())')
+
+  output=$(dpg-cli --new "$label" 2>&1)
+  exit_code=$?
+
+  end_ms=$(node -e 'console.log(Date.now())')
+  duration_ms=$((end_ms - start_ms))
+
+  if [[ "$exit_code" -ne 0 ]]; then
+    echo "FAIL: dpg-cli --new $label exited $exit_code"
+    echo "$output"
+    exit 1
+  fi
+
+  hash_abbrev=$(node -e '
+    const fs = require("fs")
+    const cfg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))
+    console.log(cfg.hashAbbrev)
+  ' "$CONFIG_FILE")
+
+  profile_count=$(node -e '
+    const fs = require("fs")
+    const profiles = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))
+    console.log(profiles.length)
+  ' "$PROFILES_FILE")
+
+  hash_lengths=$(node -e '
+    const fs = require("fs")
+    const profiles = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))
+    console.log([...new Set(profiles.map(p => p.ctxHash?.length ?? 0))].join(","))
+  ' "$PROFILES_FILE")
+
+  printf "n=%04d profiles=%s hashAbbrev=%s ctxHashLengths=%s duration=%sms\n" \
+    "$n" "$profile_count" "$hash_abbrev" "$hash_lengths" "$duration_ms"
+
+  if [[ "$hash_abbrev" -ge $HASH_LIMIT ]]; then
+    break
+  fi
+
+  n=$((n + 1))
+
+  if [[ "$n" -gt "$HARD_STOP" ]]; then
+    echo "FAIL: hashAbbrev did not reach $HASH_LIMIT within $HARD_STOP profiles"
+    exit 1
+  fi
+done
+
+echo
+echo "PASS: short-hash expansion reached hashAbbrev=${hash_abbrev}"
+
+END_TS=$(date +%s)
+DURATION=$(awk "BEGIN { printf \"%.2f\", $END_TS - $START_TS }")
+
+echo "   Start at  $START_TIME"
+echo "   Duration  ${DURATION}s"

--- a/integration/tests.tsv
+++ b/integration/tests.tsv
@@ -21,8 +21,8 @@ bump-with-save	dpg-cli -b github-main --save	password123	0	contains	(saved)	exac
 
 config-sortby	dpg-cli --config sortBy=label	-	0	contains	Updated config: sortBy=label	exact	-
 config-show-sortby	dpg-cli --config	-	0	contains	\qsortBy\q: \qlabel\q	exact	-
-config-hash-abbrev	dpg-cli --config hashAbbrev=8	-	0	contains	Updated config: hashAbbrev=8	exact	-
-config-show-hash-abbrev	dpg-cli --config	-	0	contains	\qhashAbbrev\q: 8	exact	-
+config-hash-abbrev	dpg-cli --config hashAbbrev=8	-	1	exact	-	contains	cannot be changed manually
+config-show-hash-abbrev	dpg-cli --config	-	0	contains	\qhashAbbrev\q: 7	exact	-
 config-timeout	dpg-cli --config timeout=900	-	0	contains	Updated config: timeout=900	exact	-
 config-show-timeout	dpg-cli --config	-	0	contains	\qtimeout\q: 900	exact	-
 config-bad-timeout	dpg-cli --config timeout=abc	-	1	exact	-	contains	Invalid timeout

--- a/integration/tests.tsv
+++ b/integration/tests.tsv
@@ -20,11 +20,15 @@ bump-no-save	dpg-cli -b github-main	password123	0	contains	Counter:	exact	-
 bump-with-save	dpg-cli -b github-main --save	password123	0	contains	(saved)	exact	-
 
 config-sortby	dpg-cli --config sortBy=label	-	0	contains	Updated config: sortBy=label	exact	-
-config-unsupported	dpg-cli --config sortBy=foo	-	1	exact	-	contains	Unsupported sortBy value: 'foo'
+config-show-sortby	dpg-cli --config	-	0	contains	\qsortBy\q: \qlabel\q	exact	-
+config-hash-abbrev	dpg-cli --config hashAbbrev=8	-	0	contains	Updated config: hashAbbrev=8	exact	-
+config-show-hash-abbrev	dpg-cli --config	-	0	contains	\qhashAbbrev\q: 8	exact	-
 config-timeout	dpg-cli --config timeout=900	-	0	contains	Updated config: timeout=900	exact	-
-config-show-updated	dpg-cli --config	-	0	contains	\qtimeout\q: 900	exact	-
+config-show-timeout	dpg-cli --config	-	0	contains	\qtimeout\q: 900	exact	-
 config-bad-timeout	dpg-cli --config timeout=abc	-	1	exact	-	contains	Invalid timeout
 config-editor	dpg-cli --config editor=nano	-	0	contains	Updated config: editor=nano	exact	-
+config-show-editor	dpg-cli --config	-	0	contains	\qeditor\q: \qnano\q	exact	-
+config-unsupported	dpg-cli --config sortBy=foo	-	1	exact	-	contains	Unsupported sortBy value: 'foo'
 config-bad-key	dpg-cli --config wat=x	-	1	exact	-	contains	Unknown config key
 config-bad-arg	dpg-cli --config fubar	-	1	exact	-	contains	Config update must use key=value syntax
 config-editor-with-args	dpg-cli --config \qeditor=vi -f\q	-	0	contains	Updated config: editor=vi -f	exact	-

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "test": "vitest --exclude 'test/**/*.slow.test.js'",
     "test:slow": "vitest run test/kdf.slow.test.js test/generate.slow.test.js --reporter=verbose",
+    "test:integration": "bash integration/run.sh",
+    "test:short-hash": "bash integration/short-hash/run.sh",
     "test:all": "vitest run --reporter=verbose"
   },
   "devDependencies": {

--- a/src/config-file.js
+++ b/src/config-file.js
@@ -64,17 +64,9 @@ export function applyConfigUpdate(config, key, value) {
   }
 
   if (key === 'hashAbbrev') {
-    const parsed = Number(value)
-
-    if (!Number.isInteger(parsed) || parsed < 1) {
-      throw new Error('hashAbbrev must be a positive integer')
-    }
-
-    return {
-      ...config,
-      hashAbbrev: parsed
-    }
+    throw new Error("Config key 'hashAbbrev' is managed by DPG and cannot be changed manually")
   }
+
   if (key === 'sortBy') {
     if (value !== 'label') {
       throw new Error(`Unsupported sortBy value: '${value}'`)

--- a/src/config-file.js
+++ b/src/config-file.js
@@ -12,8 +12,10 @@ function resolveConfigPath(options = {}) {
  */
 export function defaultConfig() {
   return {
-    timeout: 0,
-    sortBy: 'label'
+    editor: '',
+    hashAbbrev: 7,
+    sortBy: 'label',
+    timeout: 0
   }
 }
 
@@ -50,17 +52,29 @@ export function parseConfigAssignment(text) {
  * @returns {Config}
  */
 export function applyConfigUpdate(config, key, value) {
-  if (key === 'timeout') {
-    if (!/^\d+$/.test(value)) {
-      throw new Error(`Invalid timeout: '${value}'. Timeout must be a non-negative integer.`)
+  if (key === 'editor') {
+    if (!value) {
+      throw new Error(`No editor specified`)
     }
 
     return {
       ...config,
-      timeout: Number(value)
+      editor: value
     }
   }
 
+  if (key === 'hashAbbrev') {
+    const parsed = Number(value)
+
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      throw new Error('hashAbbrev must be a positive integer')
+    }
+
+    return {
+      ...config,
+      hashAbbrev: parsed
+    }
+  }
   if (key === 'sortBy') {
     if (value !== 'label') {
       throw new Error(`Unsupported sortBy value: '${value}'`)
@@ -72,16 +86,17 @@ export function applyConfigUpdate(config, key, value) {
     }
   }
 
-  if (key === 'editor') {
-    if (!value) {
-      throw new Error(`No editor specified`)
+  if (key === 'timeout') {
+    if (!/^\d+$/.test(value)) {
+      throw new Error(`Invalid timeout: '${value}'. Timeout must be a non-negative integer.`)
     }
 
     return {
       ...config,
-      editor: value
+      timeout: Number(value)
     }
   }
+
 
   throw new Error(`Unknown config key: '${key}'`)
 }
@@ -106,9 +121,10 @@ export async function loadConfig(options = {}) {
   const parsed = JSON.parse(text)
 
   return {
-    timeout: parsed.timeout ?? 0,
+    editor: parsed.editor ?? '',
+    hashAbbrev: parsed.hashAbbrev ?? 7,
     sortBy: parsed.sortBy ?? 'label',
-    editor: parsed.editor ?? ''
+    timeout: parsed.timeout ?? 0
   }
 }
 
@@ -124,9 +140,10 @@ export async function saveConfig(config, options = {}) {
 
   await fs.mkdir(dir, { recursive: true })
   await fs.writeFile(tmpPath, JSON.stringify({
-    timeout: config.timeout,
+    editor: config.editor ?? '',
+    hashAbbrev: config.hashAbbrev,
     sortBy: config.sortBy,
-    editor: config.editor ?? ''
+    timeout: config.timeout
   }, null, 2), 'utf8')
   await fs.rename(tmpPath, configPath)
 }

--- a/src/context-hash.js
+++ b/src/context-hash.js
@@ -5,20 +5,22 @@ import { encodeContext } from './context.js'
  * @param {Profile} profile
  * @returns string
  */
-export function computeCtxHash(profile){
+export function computeFullCtxHash(profile){
   return crypto
     .createHash('sha256')
     .update(encodeContext(profile))
     .digest('hex')}
 /**
  * @param {Profile} profile
+ * @param {number} hashAbbrev
  * @returns Profile
  */
-export function withCtxHash(profile){
+export function withCtxHash(profile, hashAbbrev){
   return {
     ...profile,
-    ctxHash: computeCtxHash(profile)
-  }}
+    ctxHash: abbreviateCtxHash(computeFullCtxHash(profile), hashAbbrev)
+  }
+}
 
 /**
  * Return copies of all profiles with ctxHash refreshed if missing.
@@ -29,10 +31,100 @@ export function withCtxHash(profile){
  * This function does not perform any persistence.
  *
  * @param {Profile[]} profiles
+ * @param {number} hashAbbrev
  * @returns {Profile[]}
  */
-export function backfillCtxHashes(profiles) {
+export function backfillCtxHashes(profiles, hashAbbrev) {
   return profiles.map(profile =>
-    profile.ctxHash ? profile : withCtxHash(profile)
+    profile.ctxHash?.length === hashAbbrev
+      ? profile
+      : withCtxHash(profile, hashAbbrev)
   )
+}
+
+/**
+ * Return the abbreviated form of a full context hash.
+ *
+ * @param {string} fullHash
+ * @param {number} hashAbbrev
+ * @returns {string}
+ */
+export function abbreviateCtxHash(fullHash, hashAbbrev) {
+  if (typeof fullHash !== 'string') {
+    throw new Error('fullHash must be a string')
+  }
+
+  if (!Number.isInteger(hashAbbrev) || hashAbbrev < 1) {
+    throw new Error('hashAbbrev must be a positive integer')
+  }
+
+  return fullHash.slice(0, hashAbbrev)
+}
+
+/**
+ * Find the minimum hash abbreviation length needed to avoid abbreviated-hash collisions.
+ *
+ * Real duplicate contexts have identical full hashes and do not require expansion.
+ *
+ * @param {Profile[]} profiles
+ * @param {number} currentHashAbbrev
+ * @param {(profile: Profile) => string} [computeFullHash]
+ * @returns {number}
+ */
+export function findRequiredHashAbbrev(
+  profiles,
+  currentHashAbbrev,
+  computeFullHash = computeFullCtxHash
+) {
+  /** @type {Map<string,Profile[]>}*/
+  const buckets = new Map()
+
+  for (const profile of profiles) {
+    const key = profile.ctxHash
+    if (!key) continue
+
+    if (!buckets.has(key)) {
+      buckets.set(key, [])
+    }
+
+    buckets.get(key).push(profile)
+  }
+
+  let required = currentHashAbbrev
+
+  for (const bucket of buckets.values()) {
+    if (bucket.length < 2) continue
+
+    const fullHashes = bucket.map(profile => computeFullHash(profile))
+    const uniqueFullHashes = [...new Set(fullHashes)]
+
+    if (uniqueFullHashes.length < 2) {
+      continue
+    }
+
+    required = Math.max(
+      required,
+      minimumDistinguishingPrefixLength(uniqueFullHashes)
+    )
+  }
+
+  return required
+}
+
+/**
+ * @param {string[]} fullHashes
+ * @returns {number}
+ */
+function minimumDistinguishingPrefixLength(fullHashes) {
+  let length = 1
+
+  while (true) {
+    const prefixes = new Set(fullHashes.map(hash => hash.slice(0, length)))
+
+    if (prefixes.size === fullHashes.length) {
+      return length
+    }
+
+    length += 1
+  }
 }

--- a/src/models.js
+++ b/src/models.js
@@ -118,10 +118,14 @@
  * @typedef {{
  *   load: (deps?: {
  *     loadAllProfiles?: () => Promise<Profile[]>,
- *     saveProfiles?: (profiles: Profile[]) => Promise<void>
+ *     saveProfiles?: (profiles: Profile[]) => Promise<void>,
+ *     saveConfig?: (config: Config) => Promise<void>
  *   }) => Promise<{
+ *     _config: Config
+ *     _saveConfig: (config: Config) => Promise<void>,
  *     _profiles: Profile[],
  *     _saveProfiles: (profiles: Profile[]) => Promise<void>,
+ *     _findRequiredHashAbbrev: () => number,
  *     list: () => Profile[],
  *     get: (label: string) => Profile | null,
  *     delete: (label: string) => void,

--- a/src/models.js
+++ b/src/models.js
@@ -40,9 +40,10 @@
 
 /**
  * @typedef {{
- *   timeout?: number,
+ *   editor?: string,
+ *   hashAbbrev?: number,
  *   sortBy?: ProfileSortField,
- *   editor?: string
+ *   timeout?: number
  * }} Config
  */
 

--- a/src/profiles-repository.js
+++ b/src/profiles-repository.js
@@ -1,30 +1,37 @@
 import {loadAllProfiles, saveProfiles} from './profiles-file.js'
-import {backfillCtxHashes, computeCtxHash, withCtxHash} from "./context-hash.js";
+import {backfillCtxHashes, computeFullCtxHash, findRequiredHashAbbrev, withCtxHash} from "./context-hash.js";
 import {encodeContext} from "./context.js";
-
+import {loadConfig, saveConfig} from "./config-file.js";
+/** @typedef {import('./models.js').Config} Config */
 /** @typedef {import('./models.js').Profile} Profile */
 
 export class ProfilesRepository {
   /**
    * @param {Profile[]} profiles
-   * @param {{ saveProfiles?: (profiles: Profile[]) => Promise<void> }} [deps]
+   * @param {{ saveProfiles?: (profiles: Profile[]) => Promise<void>, config?: Config, saveConfig?: (config: Config) => Promise<void> , findRequiredHashAbbrev?: () => number }} [deps]
    */
   constructor(profiles, deps = {}) {
     this._profiles = [...profiles]
     this._saveProfiles = deps.saveProfiles ?? saveProfiles
-  }
+    this._config = deps.config
+    this._saveConfig = deps.saveConfig ?? saveConfig
+    this._findRequiredHashAbbrev = deps.findRequiredHashAbbrev ?? findRequiredHashAbbrev  }
 
   /**
-   * @param {{ loadAllProfiles?: () => Promise<Profile[]>, saveProfiles?: (profiles: Profile[]) => Promise<void> }} [deps]
+   * @param {{ loadAllProfiles?: () => Promise<Profile[]>, loadConfig?: () => Promise<Config>, saveProfiles?: (profiles: Profile[]) => Promise<void>, saveConfig?: (config: Config) => Promise<void> }} [deps]
    * @returns {Promise<ProfilesRepository>}
    */
   static async load(deps = {}) {
     const load = deps.loadAllProfiles ?? loadAllProfiles
+    const loadCfg = deps.loadConfig ?? loadConfig
     const save = deps.saveProfiles ?? saveProfiles
+    const saveCfg = deps.saveConfig ?? saveConfig
 
-    const profiles = await load()
-    return new ProfilesRepository(backfillCtxHashes(profiles), {
-      saveProfiles: save
+    const config = await loadCfg()
+    return new ProfilesRepository(backfillCtxHashes(await load(), config.hashAbbrev), {
+      saveProfiles: save,
+      config: config,
+      saveConfig: saveCfg
     })
   }
 
@@ -50,7 +57,7 @@ export class ProfilesRepository {
     if (this.get(profile.label)) {
       throw new Error(`Profile already exists: '${profile.label}'`)
     }
-    this._profiles.push(withCtxHash(profile))
+    this._profiles.push(withCtxHash(profile, this._config.hashAbbrev))
   }
 
   /**
@@ -63,7 +70,7 @@ export class ProfilesRepository {
       throw new Error(`Profile does not exist: '${profile.label}'`)
     }
 
-    this._profiles[i] = withCtxHash(profile)
+    this._profiles[i] = withCtxHash(profile, this._config.hashAbbrev)
   }
 
   /**
@@ -83,6 +90,17 @@ export class ProfilesRepository {
    * @returns {Promise<void>}
    */
   async persist() {
+    const required = this._findRequiredHashAbbrev(this._profiles, this._config.hashAbbrev)
+
+    if (required > this._config.hashAbbrev) {
+      this._config = {
+        ...this._config,
+        hashAbbrev: required
+      }
+
+      this._profiles = this._profiles.map(profile => withCtxHash(profile, required))
+      await this._saveConfig(this._config)
+    }
     await this._saveProfiles(this._profiles)
   }
 
@@ -94,7 +112,7 @@ export class ProfilesRepository {
     const buckets = new Map()
 
     for (const profile of this._profiles) {
-      const hash = profile.ctxHash ?? computeCtxHash(profile)
+      const hash = profile.ctxHash ?? computeFullCtxHash(profile)
 
       if (!buckets.has(hash)) {
         buckets.set(hash, [])

--- a/test/config-file.test.js
+++ b/test/config-file.test.js
@@ -64,19 +64,12 @@ describe('applyConfigUpdate', () => {
     })
   })
 
-  it('updates hashAbbrev', () => {
-    expect(applyConfigUpdate(defaultConfig(), 'hashAbbrev', '8')).toEqual({
-      editor: '',
-      hashAbbrev: 8,
-      sortBy: 'label',
-      timeout: 0
-    })
-  })
-
-  it('rejects invalid hashAbbrev', () => {
+  it('rejects manual updates to hashAbbrev', () => {
     expect(() =>
-      applyConfigUpdate(defaultConfig(), 'hashAbbrev', 'nope')
-    ).toThrow(/hashAbbrev must be a positive integer/i)
+      applyConfigUpdate(defaultConfig(), 'hashAbbrev', '8')
+    ).toThrow(
+      /Config key 'hashAbbrev' is managed by DPG and cannot be changed manually/
+    )
   })
 
   it('updates sortBy', () => {

--- a/test/config-file.test.js
+++ b/test/config-file.test.js
@@ -14,8 +14,10 @@ import { makeConfig } from './fixtures/config.js'
 describe('defaultConfig', () => {
   it('returns the default config', () => {
     expect(defaultConfig()).toEqual({
+      editor: '',
+      hashAbbrev: 7,
+      sortBy: 'label',
       timeout: 0,
-      sortBy: 'label'
     })
   })
 })
@@ -55,23 +57,43 @@ describe('parseConfigAssignment', () => {
 describe('applyConfigUpdate', () => {
   it('updates timeout', () => {
     expect(applyConfigUpdate(defaultConfig(), 'timeout', '900')).toEqual({
+      editor: '',
+      hashAbbrev: 7,
+      sortBy: 'label',
       timeout: 900,
-      sortBy: 'label'
     })
+  })
+
+  it('updates hashAbbrev', () => {
+    expect(applyConfigUpdate(defaultConfig(), 'hashAbbrev', '8')).toEqual({
+      editor: '',
+      hashAbbrev: 8,
+      sortBy: 'label',
+      timeout: 0
+    })
+  })
+
+  it('rejects invalid hashAbbrev', () => {
+    expect(() =>
+      applyConfigUpdate(defaultConfig(), 'hashAbbrev', 'nope')
+    ).toThrow(/hashAbbrev must be a positive integer/i)
   })
 
   it('updates sortBy', () => {
     expect(applyConfigUpdate(defaultConfig(), 'sortBy', 'label')).toEqual({
-      timeout: 0,
-      sortBy: 'label'
+      editor: '',
+      hashAbbrev: 7,
+      sortBy: 'label',
+      timeout: 0
     })
   })
 
   it('updates editor', () => {
     expect(applyConfigUpdate(defaultConfig(), 'editor', 'nano')).toEqual({
-      timeout: 0,
+      editor: 'nano',
+      hashAbbrev: 7,
       sortBy: 'label',
-      editor: 'nano'
+      timeout: 0
     })
   })
 
@@ -105,9 +127,10 @@ describe('saveConfig', () => {
 
     const text = await fs.readFile(configPath, 'utf8')
     expect(JSON.parse(text)).toEqual({
-      timeout: 900,
+      editor: '',
+      hashAbbrev: 7,
       sortBy: 'label',
-      editor: ''
+      timeout: 900
     })
   })
 })

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -24,9 +24,10 @@ describe('list command', () => {
     const parsed = JSON.parse(output)
 
     expect(parsed).toEqual({
-      timeout: 900,
+      editor: '',
+      hashAbbrev: 7,
       sortBy: 'label',
-      editor: ''
+      timeout: 900
     })
   })
 
@@ -47,9 +48,10 @@ describe('list command', () => {
 
     expect(exitCode).toBe(0)
     expect(savedConfig).toEqual({
-      timeout: 900,
+      editor: '',
+      hashAbbrev: 7,
       sortBy: 'label',
-      editor: ''
+      timeout: 900
     })
     expect(stdout.write).toHaveBeenCalledWith('Updated config: timeout=900\n')
   })
@@ -71,9 +73,10 @@ describe('list command', () => {
 
     expect(exitCode).toBe(0)
     expect(savedConfig).toEqual({
-      timeout: 0,
+      editor: '',
+      hashAbbrev: 7,
       sortBy: 'label',
-      editor: ''
+      timeout: 0
     })
     expect(stdout.write).toHaveBeenCalledWith('Updated config: sortBy=label\n')
   })
@@ -128,9 +131,10 @@ describe('list command', () => {
 
     expect(exitCode).toBe(0)
     expect(savedConfig).toEqual({
-      timeout: 0,
+      editor: 'nano',
+      hashAbbrev: 7,
       sortBy: 'label',
-      editor: 'nano'
+      timeout: 0
     })
     expect(stdout.write).toHaveBeenCalledWith('Updated config: editor=nano\n')
   })

--- a/test/context-hash.test.js
+++ b/test/context-hash.test.js
@@ -1,48 +1,119 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import {makeProfile} from "./fixtures/profiles.js";
-import {computeCtxHash, withCtxHash} from "../src/context-hash.js";
+import {
+  abbreviateCtxHash,
+  backfillCtxHashes,
+  computeFullCtxHash,
+  findRequiredHashAbbrev,
+  withCtxHash
+} from "../src/context-hash.js";
 
 describe('context hashes', () => {
   it('computes the same ctxHash for equivalent canonical contexts', () => {
     const a = makeProfile({symbolSet: '!@#', require: ['symbol', 'lower']})
     const b = makeProfile({symbolSet: '@!#', require: ['lower', 'symbol']})
 
-    expect(computeCtxHash(a)).toBe(computeCtxHash(b))
+    expect(computeFullCtxHash(a)).toBe(computeFullCtxHash(b))
   })
 
   it('computes different ctxHash values for different counters', () => {
     const a = makeProfile({counter: 1})
     const b = makeProfile({counter: 2})
 
-    expect(computeCtxHash(a)).not.toBe(computeCtxHash(b))
+    expect(computeFullCtxHash(a)).not.toBe(computeFullCtxHash(b))
   })
 
   it('does not include ctxHash itself in the context hash', () => {
     const a = makeProfile({ctxHash: 'old-hash'})
     const b = makeProfile({ctxHash: 'different-old-hash'})
 
-    expect(computeCtxHash(a)).toBe(computeCtxHash(b))
+    expect(computeFullCtxHash(a)).toBe(computeFullCtxHash(b))
   })
 
   it('adds ctxHash to a profile', () => {
     const profile = makeProfile({ctxHash: undefined})
-    const updated = withCtxHash(profile)
+    const updated = withCtxHash(profile, 7)
 
-    expect(updated.ctxHash).toBe(computeCtxHash(profile))
+    expect(updated.ctxHash).toBe(abbreviateCtxHash(computeFullCtxHash(profile), 7))
   })
 
   it('replaces stale ctxHash', () => {
     const profile = makeProfile({ctxHash: 'stale'})
-    const updated = withCtxHash(profile)
+    const updated = withCtxHash(profile, 7)
 
-    expect(updated.ctxHash).toBe(computeCtxHash(profile))
+    expect(updated.ctxHash).toBe(abbreviateCtxHash(computeFullCtxHash(profile), 7))
   })
 
   it('does not mutate the original profile', () => {
     const profile = makeProfile({ctxHash: 'stale'})
-    const updated = withCtxHash(profile)
+    const updated = withCtxHash(profile, 7)
 
     expect(updated).not.toBe(profile)
     expect(profile.ctxHash).toBe('stale')
+  })
+
+  it('abbreviates full hashes to requested length', () => {
+    expect(abbreviateCtxHash('abcdef123456', 7)).toBe('abcdef1')
+  })
+
+  it('stores abbreviated ctxHash on profile', () => {
+    const profile = withCtxHash(makeProfile({ label: 'github-main' }), 7)
+
+    expect(profile.ctxHash).toHaveLength(7)
+    expect(profile.ctxHash).toBe(
+      abbreviateCtxHash(computeFullCtxHash(profile), 7)
+    )
+  })
+
+  it('does not include ctxHash itself in the full hash', () => {
+    const a = makeProfile({ ctxHash: 'aaaaaaa' })
+    const b = makeProfile({ ctxHash: 'bbbbbbb' })
+
+    expect(computeFullCtxHash(a)).toBe(computeFullCtxHash(b))
+  })
+
+  it('backfills missing ctxHash only', () => {
+    const missing = makeProfile({ label: 'missing', ctxHash: undefined })
+    const existing = makeProfile({ label: 'existing', ctxHash: '1234567' })
+
+    const result = backfillCtxHashes([missing, existing], 7)
+
+    expect(result[0].ctxHash).toHaveLength(7)
+    expect(result[1].ctxHash).toBe('1234567')
+  })
+
+  it('refreshes wrong-length ctxHash', () => {
+    const profile = makeProfile({ ctxHash: 'abc' })
+
+    const result = backfillCtxHashes([profile], 7)
+
+    expect(result[0].ctxHash).toHaveLength(7)
+    expect(result[0].ctxHash).not.toBe('abc')
+  })
+
+  it('does not compute full hashes when abbreviated hashes are unique', () => {
+    const profiles = [
+      makeProfile({ label: 'a', ctxHash: 'abc1234' }),
+      makeProfile({ label: 'b', ctxHash: 'def5678' })
+    ]
+
+    const computeFullHash = vi.fn()
+
+    expect(findRequiredHashAbbrev(profiles, 7, computeFullHash)).toBe(7)
+    expect(computeFullHash).not.toHaveBeenCalled()
+  })
+
+  it('expands when same abbreviation has different full hashes', () => {
+    const profiles = [
+      makeProfile({ label: 'a', ctxHash: 'abc' }),
+      makeProfile({ label: 'b', ctxHash: 'abc' })
+    ]
+
+    const computeFullHash = vi.fn(profile => ({
+      a: 'abc1ffff',
+      b: 'abc2ffff'
+    }[profile.label]))
+
+    expect(findRequiredHashAbbrev(profiles, 3, computeFullHash)).toBe(4)
   })
 })

--- a/test/fixtures/config.js
+++ b/test/fixtures/config.js
@@ -2,9 +2,10 @@
 
 /** @type {Config} */
 export const DEFAULT_CONFIG = {
-  timeout: 0,
+  editor: '',
+  hashAbbrev: 7,
   sortBy: 'label',
-  editor: ''
+  timeout: 0
 }
 
 /**

--- a/test/mocks/profiles-repository.js
+++ b/test/mocks/profiles-repository.js
@@ -22,6 +22,9 @@ export function profilesRepositoryClassMock(initialProfiles, overrides = {}) {
   const repo = {
     _profiles: [],
     _saveProfiles: undefined,
+    _config: undefined,
+    _saveConfig: undefined,
+    _findRequiredHashAbbrev: undefined,
 
     list: () => [...profiles],
 

--- a/test/profiles-repository.test.js
+++ b/test/profiles-repository.test.js
@@ -6,6 +6,7 @@ import path from "node:path";
 import { tmpdir } from "node:os";
 import { loadAllProfiles, saveProfiles } from '../src/profiles-file.js'
 /** @typedef {import('../src/models.js').Profile} Profile */
+/** @typedef {import('../src/models.js').Config} Config */
 
 const _loadAllProfiles = async () => [makeProfile({label: 'github-main'})]
 
@@ -188,5 +189,30 @@ describe('ProfilesRepository exceptions', () => {
     expect(() =>
       repo.delete('ghost')
     ).toThrow(/does not exist/)
+  })
+
+  it('expands hashAbbrev and rewrites profile hashes on abbreviated collision', async () => {
+    /** @type {Config | null} */
+    let savedConfig = null
+
+    /** @type {Profile[] | null} */
+    let savedProfiles = null
+
+    const repo = new ProfilesRepository(
+      [
+        makeProfile({ label: 'a', ctxHash: 'abc' }),
+        makeProfile({ label: 'b', ctxHash: 'abc' })
+      ],
+      {
+        config: { timeout: 90, sortBy: 'label', editor: '', hashAbbrev: 3 },
+        findRequiredHashAbbrev: () => 4,
+        saveConfig: async config => { savedConfig = config },
+        saveProfiles: async profiles => { savedProfiles = profiles }
+      }
+    )
+    await repo.persist()
+
+    expect(savedConfig.hashAbbrev).toBeGreaterThan(3)
+    expect(savedProfiles.every(p => p.ctxHash.length === savedConfig.hashAbbrev)).toBe(true)
   })
 })


### PR DESCRIPTION
# DPG-035: Adaptive abbreviated context hashes

## Summary

Introduce adaptive abbreviated context hashes for profile persistence.

Profiles now store shortened `ctxHash` values while preserving safe duplicate-context detection and automatically expanding the abbreviation length only when required.

The implementation is intentionally modeled after Git's abbreviated hash behavior.

---

## Highlights

### Adaptive abbreviated hashes

Profiles now persist abbreviated context hashes using the configured `hashAbbrev` length.

Example:

```json
{
  "ctxHash": "a1b2c3d"
}
```

instead of storing full hashes.

---

### Automatic collision handling

When abbreviated hashes collide:

- full hashes are compared lazily
- real duplicate contexts remain valid
- abbreviated-hash collisions trigger automatic expansion

The repository calculates the minimum required abbreviation length and rewrites all persisted hashes accordingly.

---

### Repository-owned maintenance

Hash maintenance is now fully owned by `ProfilesRepository`.

CLI command handlers remain completely unaware of:

- abbreviation logic
- collision analysis
- automatic expansion

This keeps the behavior deterministic and centralized.

---

## Config changes

Added:

```json
{
  "hashAbbrev": 7
}
```

Important:

- `hashAbbrev` is managed internally by DPG
- users cannot modify it manually via `--config`
- the repository updates it automatically when expansion is required

---

## Implementation details

### New helpers

Added pure hashing helpers:

- `computeFullCtxHash`
- `abbreviateCtxHash`
- `withCtxHash`
- `backfillCtxHashes`
- `findRequiredHashAbbrev`

### Lazy full-hash evaluation

Full hashes are only computed for profiles that already share the same abbreviated hash.

This avoids unnecessary hashing work during normal operation.

### Backfilling and normalization

Repository loading now:

- backfills missing hashes
- refreshes wrong-length hashes
- preserves existing valid hashes

---

## Testing

### Unit tests

Added tests covering:

- abbreviated hash generation
- deterministic full hashes
- collision analysis
- adaptive expansion logic
- repository persistence behavior
- stale/wrong-length hash normalization

### Integration tests

Existing integration tests updated for abbreviated hashes.

Added a dedicated short-hash integration/performance suite:

```bash
npm run test:short-hash
```

This suite:

- starts from `hashAbbrev = 1`
- repeatedly creates profiles
- forces adaptive expansion
- validates persistence correctness
- measures performance characteristics

---

## Performance observations

Measured on a 2019 Intel MacBook Pro:

| hashAbbrev reached | profiles required |
|---|---:|
| 2 | 3 |
| 3 | 29 |
| 4 | 85 |
| 5 | 252 |
| 6 | 408 |
| 7 | 1409 |

Representative timings:

| profiles | hashAbbrev | duration |
|---|---:|---:|
| 1000 | 6 | 357ms |
| 1409 (expansion to 7) | 7 | 577ms |

Result:

- adaptive maintenance remains comfortably fast
- no user-facing progress message is required
- default `hashAbbrev = 7` appears conservative and appropriate

---

## Additional cleanup

- Added npm scripts for integration suites
- Added executable integration scripts
- Added documentation for adaptive hash behavior
- Removed obsolete helpers and references

---

## Result

DPG now supports:

- compact persisted context hashes
- safe abbreviated-hash collision handling
- deterministic automatic expansion
- scalable duplicate-context detection

without exposing complexity to CLI callers or users.